### PR TITLE
Fixed #48

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -55,7 +55,7 @@ class HomeController extends Controller
     protected function back()
     {
         $campaign = Session::get('campaign_id');
-        if (empty($campaign)) {
+        if (empty($campaign) || !isset($campaign) || Auth::user()->campaign()->count() == 0) {
             return redirect()->route('campaigns.index');
         }
 


### PR DESCRIPTION
Fixed #48 by redirecting users without a campaign to the 'make a campaign'-flow, checking whether session('campaign_id') is set or Logged in user has no campaigns (i believe User->campaign will return campaigns where user is either owner or member, so this shouldn't screw over users that don't own a campaign, correct me if i'm wrong)