### PR TITLE
css fix for ckeditor full screen mode

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -179,3 +179,10 @@ tr.entity-hidden {
   height: 70px;
   width: 50px;
 }
+
+/**
+ * vendor layout fix for ckeditor full screen mode
+ */
+div.mce-fullscreen {
+    z-index: 1400;
+}


### PR DESCRIPTION
Fixing #62 
According to thoses two rules :
.main-sidebar {
    z-index: 810;
}
.main-header {
    z-index: 1030;
}
I think the simpliest option is to win the z-index battle.