### PR TITLE
Proposal: bulk permissions editing

### DIFF
--- a/resources/lang/de/crud.php
+++ b/resources/lang/de/crud.php
@@ -251,6 +251,7 @@ return [
         'action'    => 'Aktion',
         'actions'   => [
             'bulk'          => [
+                'ignore'    => 'Ignorieren',
                 'add'       => 'Hinzufügen',
                 'remove'    => 'Entfernen',
             ],

--- a/resources/lang/en/crud.php
+++ b/resources/lang/en/crud.php
@@ -265,6 +265,7 @@ return [
         'action'    => 'Action',
         'actions'   => [
             'bulk'          => [
+                'ignore'    => 'Ignore',
                 'add'       => 'Add',
                 'remove'    => 'Remove',
             ],

--- a/resources/lang/es/crud.php
+++ b/resources/lang/es/crud.php
@@ -265,6 +265,7 @@ return [
         'action'        => 'Acción',
         'actions'       => [
             'bulk'          => [
+                'ignore'    => 'Ignorar',
                 'add'       => 'Añadir',
                 'remove'    => 'Eliminar',
             ],

--- a/resources/lang/fr/crud.php
+++ b/resources/lang/fr/crud.php
@@ -265,6 +265,7 @@ return [
         'action'        => 'Action',
         'actions'       => [
             'bulk'          => [
+                'ignore'    => 'Ignorer',
                 'add'       => 'Ajouter',
                 'remove'    => 'Retirer',
             ],

--- a/resources/lang/it/crud.php
+++ b/resources/lang/it/crud.php
@@ -250,6 +250,7 @@ return [
         'action'    => 'Azione',
         'actions'   => [
             'bulk'          => [
+                'ignore'    => 'Ignorare',
                 'add'       => 'Aggiungi',
                 'remove'    => 'Rimuovi',
             ],

--- a/resources/views/cruds/datagrids/modals.blade.php
+++ b/resources/views/cruds/datagrids/modals.blade.php
@@ -73,28 +73,28 @@
                                     {!! Form::select(
                                     'user[' . $member->user_id . '][read]',
                                     __('crud.permissions.actions.bulk'),
-                                    null,
+                                    'ignore',
                                     ['class' => 'form-control']) !!}
                                 </td>
                                 <td>
                                     {!! Form::select(
                                     'user[' . $member->user_id . '][edit]',
                                     __('crud.permissions.actions.bulk'),
-                                    null,
+                                    'ignore',
                                     ['class' => 'form-control']) !!}
                                 </td>
                                 <td>
                                     {!! Form::select(
                                     'user[' . $member->user_id . '][delete]',
                                     __('crud.permissions.actions.bulk'),
-                                    null,
+                                    'ignore',
                                     ['class' => 'form-control']) !!}
                                 </td>
                                 <td>
                                     {!! Form::select(
                                     'user[' . $member->user_id . '][entity-notes]',
                                     __('crud.permissions.actions.bulk'),
-                                    null,
+                                    'ignore',
                                     ['class' => 'form-control']) !!}
                                 </td>
                             </tr>
@@ -102,16 +102,6 @@
                     @endforeach
                     </tbody>
                 </table>
-
-                <div class="form-group">
-                    <label>
-                        <input type="checkbox" name="permission-override">
-                        {{ __('crud.bulk.permissions.fields.override') }}
-                    </label>
-                    <p class="help-block">
-                        {{ __('crud.bulk.permissions.helpers.override') }}
-                    </p>
-                </div>
             </div>
             <div class="modal-footer">
                 <a href="#" class="pull-left" data-dismiss="modal">{{ __('crud.cancel') }}</a>


### PR DESCRIPTION
This pull request is a proposal to change some behavior of the bulk permissions editing dialog.

* The "override" boolean switch is removed from the dialog;
* Permission drop-downs include a third option, 'ignore', which replaces the "override" behavior. This new option becomes the default for each drop-down, so that a permissions change must be explicitly chosen.

Rationale: bulk-editing of permissions are usually performed in order to change a limited number of values, making a default of not changing a value easier for the admin to handle. When the list of subjects grows, having to select the desired value (and thereby remember what the original value is for a value that should not change) for each subject/permission combination becomes tedious and potentially error-prone, resulting in some undesired permissions values.

No code changes are included, since adding the 'ignore' action results in the (if-elseif) code path for altering permissions to skip over the 'add' and 'remove' behavior, as intended.