### PR TITLE
Fix word break issues in list groups

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -630,7 +630,7 @@ div.mce-fullscreen {
 
 
 .list-group-item {
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .input-error {


### PR DESCRIPTION
Currently list groups have line breaks in the middle of words quite
frequently for me. This addresses the issue, and prioritises line breaks
at the ends of words rather than the middle of them.

If a word is longer than the container, then it will still break in the
middle of the word, but I think that's fine – it's better than it
overflowing.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img width="182" alt="Before" src="https://user-images.githubusercontent.com/138944/74532144-5c0e1600-4f26-11ea-81b6-59a6f437d99b.png"></td><td><img width="184" alt="After" src="https://user-images.githubusercontent.com/138944/74532147-5dd7d980-4f26-11ea-94f3-f75c0c68cd40.png"></td></tr>
</table>