### PR TITLE
Show Organisations in Character side panel

### DIFF
--- a/resources/views/characters/_menu.blade.php
+++ b/resources/views/characters/_menu.blade.php
@@ -18,6 +18,17 @@
                     <br class="clear" />
                 </li>
             @endif
+            @if ($campaign->enabled('organisations') && !$model->organisations->isEmpty())
+                <li class="list-group-item">
+                    <b>{{ __('characters.show.tabs.organisations') }}</b>
+                    <span class="pull-right">
+                        @foreach ($model->organisations->sortBy('organisation.name') as $Org)
+                            {!! $Org->organisation->tooltipedLink() !!}@if (!$loop->last),  @endif
+	                    @endforeach
+                    </span>
+                    <br class="clear" />
+                </li>
+            @endif
             @include('cruds.lists.location')
             @if ($campaign->enabled('races') && $model->race)
                 <li class="list-group-item">


### PR DESCRIPTION
[Related Trello](https://trello.com/c/eWspOVZf/325-pin-organisation-membership)

I made a thing :3
You may not want it; that’s fine, I needed something simple to practice with.

You might want to:
- place it somewhere else in the sidebar,
- make a dedicated `characters.fields.organisations` string for it (I used the one from the tabs menu),
- rename some variables,
- make it optional or include roles as in ArcOnyx’s request?

I basically copied the new Notes sidebar list mixed with other bits.

Tested with 0, 1 and 3 organisations, as well as the Organisations module turned off; no visible breakage.