### PR TITLE
add "snazzymaps.com/embed" to SafeIframeRegexp

### DIFF
--- a/config/purify.php
+++ b/config/purify.php
@@ -169,6 +169,7 @@ return [
             . "docs.google.com/|"
             . "drive.google.com/|"
             . "www.google.com/maps/embed|"
+            . "snazzymaps.com/embed|"
             . "lookingforgm\.com/campaign/|"
             . "w.soundcloud.com/player/|"
             . "p3d\.in/e/"


### PR DESCRIPTION
Adds snazzymaps' embed path to the list of safe iframes.


- snazzymaps.com (no affiliation, just a user)
Is a service to stylize google maps, providing a great assed to "fake earth" or alternative-reality RPG content.