### PR TITLE
Fix dependency php version error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache
+FROM php:7.4-apache
 
 RUN apt-get update \
     && apt-get install -y git zip authbind vim libpng-dev libzip-dev libpq-dev netcat \


### PR DESCRIPTION
When building with docker-compose it prompts with an error because of php 7.3, changing to 7.4 fixes the error.