### PR TITLE
whitelist mapbox for interactive map use

### DIFF
--- a/config/purify.php
+++ b/config/purify.php
@@ -176,7 +176,7 @@ return [
             . "www\.aonprd\.com/|"
             . "2e\.aonprd\.com/|"
             . "www\.aonsrd\.com/|"
-            . "p3d\.in/e/"
+            . "p3d\.in/e/|"
             . "api\.mapbox\.com/"
             . ")%",
     ],


### PR DESCRIPTION
This should allow users to embed interactive maps from [Mapbox](https://www.mapbox.com/), which is used by a lot of GIS programmers for web mapping.  If you're curious as to how this fits into fantasy mapping, here's a [cool tutorial](https://www.youtube.com/watch?v=WIqd_WK2cvM) that I found (note that I do not have any affiliation with him or any of the applications in his video).

Here is the [Trello ticket](https://trello.com/c/E5r2Uoo0/566-iframe-whitelisting-mapbox).  I was actually the original requester and when I remembered that Kanka was open source, I thought I'd make a quick edit.