### PR TITLE
Fixed a migration issue when creating a fresh database

### DIFF
--- a/database/migrations/2021_11_19_034012_update_entities_add_type_id.php
+++ b/database/migrations/2021_11_19_034012_update_entities_add_type_id.php
@@ -14,7 +14,7 @@ class UpdateEntitiesAddTypeId extends Migration
     public function up()
     {
         Schema::table('entities', function (Blueprint $table) {
-            if (!app()->environment('testing')) {
+            if (!app()->environment('testing') && !Schema::hasColumn('entities', 'type_id')) {
                 $table->unsignedInteger('type_id')->after('type')->nullable();
             }
             $table->foreign('type_id')->references('id')->on('entity_types')->cascadeOnDelete();


### PR DESCRIPTION
The type_id column of the entities table is created in the "2017_11_30_112852_create_entities_table.php" migration. When creating a fresh database the "2021_11_19_034012_update_entities_add_type_id.php" migration attempt to add the column type_id and fail since it was already created in a previous migration