### PR TITLE
Fix MariaDB strict mode error in PremiumController

### DIFF
--- a/app/Http/Controllers/Settings/PremiumController.php
+++ b/app/Http/Controllers/Settings/PremiumController.php
@@ -40,8 +40,8 @@ class PremiumController extends Controller
         $premiums = $user->boosts()
             ->with(['campaign', 'campaign.boosts', 'campaign.boosts.user'])
             ->has('campaign')
-            ->groupBy('campaign_id')
-            ->get();
+            ->get()
+            ->unique('campaign_id');
         $userCampaigns = $user->campaigns()->with(['boosts', 'boosts.user'])->unboosted()->whereNotIn('campaigns.id', $premiums->pluck('campaign_id'))->get();
 
         if (! empty($campaignId)) {


### PR DESCRIPTION
# Fix MariaDB strict mode error in PremiumController

**Local setup** 
I'm running Kanka on a private VPS using ubuntu 25 and mariadb 11.8.3 for my 1 campaign. 

**When**
This issue occured to me when i wanted to set an map icon, and it is not a premium world. the link to make it premium in the description resulted in a 500 server error.  

**Problem:** 
SQLSTATE[42000]: 'kanka.campaign_boosts.id' isn't in GROUP BY — MariaDB's ONLY_FULL_GROUP_BY mode rejects SELECT * when only campaign_id is in the GROUP BY clause.
Change: In PremiumController@index, replaced the SQL-level deduplication:
```php
// Before
->groupBy('campaign_id')
->get();

// After
->get()
->unique('campaign_id');
```

Reasoning: Using Laravel's collection unique() achieves the same result (one boost entry per campaign) without triggering the strict SQL mode violation.


**Sidenote**
Not sure if you accept community PR's but 5 mins of my time to make this PR (as I had to fix it for my own server anyway) seems reasonable in the spirit of open source. 


**Stacktrace**

```log
[2026-03-14 14:42:04] production.ERROR: SQLSTATE[42000]: Syntax error or access violation: 1055 'kanka.campaign_boosts.id' isn't in GROUP BY (Connection: mariadb, SQL: select * from `campaign_boosts` where `campaign_boosts`.`user_id` = 1 and `campaign_boosts`.`user_id` is not null and exists (select * from `campaigns` where `campaign_boosts`.`campaign_id` = `campaigns`.`id` and `campaigns`.`deleted_at` is null) and `campaign_boosts`.`deleted_at` is null group by `campaign_id`) {"userId":1,"exception":"[object] (Illuminate\\Database\\QueryException(code: 42000): SQLSTATE[42000]: Syntax error or access violation: 1055 'kanka.campaign_boosts.id' isn't in GROUP BY (Connection: mariadb, SQL: select * from `campaign_boosts` where `campaign_boosts`.`user_id` = 1 and `campaign_boosts`.`user_id` is not null and exists (select * from `campaigns` where `campaign_boosts`.`campaign_id` = `campaigns`.`id` and `campaigns`.`deleted_at` is null) and `campaign_boosts`.`deleted_at` is null group by `campaign_id`) at /home/kanka/wwwroot/vendor/laravel/framework/src/Illuminate/Database/Connection.php:825)
```