### PR TITLE
feat: PayPal subscription expiry reminder and renewal

### DIFF
--- a/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
+++ b/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
@@ -12,12 +12,28 @@ class PaypalExpiringCommand extends Command
 {
     use HasJobLog;
 
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
     protected $signature = 'subscriptions:paypal-expiring';
 
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
     protected $description = 'Alert PayPal subscribers whose subscription expires in 14 days';
 
+    /** @var int Number of alerts sent */
     protected int $count = 0;
 
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
     public function __construct()
     {
         parent::__construct();
@@ -29,11 +45,11 @@ class PaypalExpiringCommand extends Command
         $log = "Looking for PayPal subscriptions expiring on {$target}";
         $this->info($log);
 
-        User::whereHas('subscriptions', function ($query) use ($target): void {
+        User::whereHas('subscriptions', function (\Illuminate\Database\Eloquent\Builder $query) use ($target): void {
             $query->where('stripe_price', 'like', 'paypal_%')
                 ->whereDate('ends_at', $target);
         })
-            ->chunk(100, function ($users): void {
+            ->chunk(100, function (\Illuminate\Support\Collection $users): void {
                 foreach ($users as $user) {
                     $this->notify($user);
                 }

--- a/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
+++ b/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
@@ -29,16 +29,6 @@ class PaypalExpiringCommand extends Command
     /** @var int Number of alerts sent */
     protected int $count = 0;
 
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     public function handle(): int
     {
         $target = Carbon::now()->addDays(14)->toDateString();

--- a/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
+++ b/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
@@ -7,6 +7,8 @@ use App\Models\User;
 use App\Traits\HasJobLog;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 class PaypalExpiringCommand extends Command
 {
@@ -45,11 +47,11 @@ class PaypalExpiringCommand extends Command
         $log = "Looking for PayPal subscriptions expiring on {$target}";
         $this->info($log);
 
-        User::whereHas('subscriptions', function (\Illuminate\Database\Eloquent\Builder $query) use ($target): void {
+        User::whereHas('subscriptions', function (Builder $query) use ($target): void {
             $query->where('stripe_price', 'like', 'paypal_%')
                 ->whereDate('ends_at', $target);
         })
-            ->chunk(100, function (\Illuminate\Support\Collection $users): void {
+            ->chunk(100, function (Collection $users): void {
                 foreach ($users as $user) {
                     $this->notify($user);
                 }

--- a/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
+++ b/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
@@ -7,8 +7,6 @@ use App\Models\User;
 use App\Traits\HasJobLog;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Collection;
 
 class PaypalExpiringCommand extends Command
 {
@@ -47,11 +45,11 @@ class PaypalExpiringCommand extends Command
         $log = "Looking for PayPal subscriptions expiring on {$target}";
         $this->info($log);
 
-        User::whereHas('subscriptions', function (Builder $query) use ($target): void {
+        User::whereHas('subscriptions', function ($query) use ($target): void {
             $query->where('stripe_price', 'like', 'paypal_%')
                 ->whereDate('ends_at', $target);
         })
-            ->chunk(100, function (Collection $users): void {
+            ->chunk(100, function ($users): void {
                 foreach ($users as $user) {
                     $this->notify($user);
                 }

--- a/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
+++ b/app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands\Subscriptions;
+
+use App\Jobs\Emails\Subscriptions\PaypalExpiringAlert;
+use App\Models\User;
+use App\Traits\HasJobLog;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class PaypalExpiringCommand extends Command
+{
+    use HasJobLog;
+
+    protected $signature = 'subscriptions:paypal-expiring';
+
+    protected $description = 'Alert PayPal subscribers whose subscription expires in 14 days';
+
+    protected int $count = 0;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $target = Carbon::now()->addDays(14)->toDateString();
+        $log = "Looking for PayPal subscriptions expiring on {$target}";
+        $this->info($log);
+
+        User::whereHas('subscriptions', function ($query) use ($target): void {
+            $query->where('stripe_price', 'like', 'paypal_%')
+                ->whereDate('ends_at', $target);
+        })
+            ->chunk(100, function ($users): void {
+                foreach ($users as $user) {
+                    $this->notify($user);
+                }
+            });
+
+        $this->info('Alerted ' . $this->count . ' subscribers.');
+        $log .= '<br />' . 'Alerted ' . $this->count . ' subscribers.';
+
+        $this->log($log);
+
+        return 0;
+    }
+
+    protected function notify(User $user): void
+    {
+        if (! $user->subscribed('kanka')) {
+            return;
+        }
+
+        PaypalExpiringAlert::dispatch($user);
+        $this->count++;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ use App\Console\Commands\Report\Weekly;
 use App\Console\Commands\Subscriptions\EndFreeTrials;
 use App\Console\Commands\Subscriptions\EndSubscriptions;
 use App\Console\Commands\Subscriptions\ExpiringCardCommand;
+use App\Console\Commands\Subscriptions\PaypalExpiringCommand;
 use App\Console\Commands\Users\RegenerateDiscordToken;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -42,6 +43,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(AnonymiseUserLogs::class)->onOneServer()->daily();
         $schedule->command(EndSubscriptions::class)->onOneServer()->dailyAt('00:05')->sentryMonitor();
         $schedule->command(EndFreeTrials::class)->onOneServer()->dailyAt('00:01');
+        $schedule->command(PaypalExpiringCommand::class)->onOneServer()->dailyAt('06:30')->sentryMonitor();
         $schedule->command(RegenerateDiscordToken::class)->onOneServer()->dailyAt('00:15');
         $schedule->command(VisibileEntityCountCommand::class)->onOneServer()->dailyAt('01:00');
         $schedule->command(CleanupTrashed::class)->onOneServer()->dailyAt('01:15');

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -43,7 +43,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(AnonymiseUserLogs::class)->onOneServer()->daily();
         $schedule->command(EndSubscriptions::class)->onOneServer()->dailyAt('00:05')->sentryMonitor();
         $schedule->command(EndFreeTrials::class)->onOneServer()->dailyAt('00:01');
-        $schedule->command(PaypalExpiringCommand::class)->onOneServer()->dailyAt('06:30')->sentryMonitor();
+        $schedule->command(PaypalExpiringCommand::class)->onOneServer()->dailyAt('06:30');
         $schedule->command(RegenerateDiscordToken::class)->onOneServer()->dailyAt('00:15');
         $schedule->command(VisibileEntityCountCommand::class)->onOneServer()->dailyAt('01:00');
         $schedule->command(CleanupTrashed::class)->onOneServer()->dailyAt('01:15');

--- a/app/Enums/UserAction.php
+++ b/app/Enums/UserAction.php
@@ -38,6 +38,8 @@ enum UserAction: int
     case yearlyRenewWarning = 81;
     case subCancelManual = 82;
     case subCancelAuto = 83;
+    case subPaypalExpiringWarning = 84;
+    case subPaypalRenew = 85;
     case paymentEdit = 86;
     case paymentAuto = 87;
     case campaignBoost = 90;

--- a/app/Http/Controllers/Entity/Abilities/ReorderController.php
+++ b/app/Http/Controllers/Entity/Abilities/ReorderController.php
@@ -11,9 +11,7 @@ use Illuminate\Database\Query\JoinClause;
 
 class ReorderController extends Controller
 {
-    public function __construct(protected ReorderService $reorderService)
-    {
-    }
+    public function __construct(protected ReorderService $reorderService) {}
 
     public function index(Campaign $campaign, Entity $entity)
     {

--- a/app/Http/Controllers/PayPalController.php
+++ b/app/Http/Controllers/PayPalController.php
@@ -37,7 +37,7 @@ class PayPalController extends Controller
             ->tier($tier)
             ->process();
 
-        if (isset($response['id']) && $response['id'] != null) {
+        if (isset($response['id'])) {
             foreach ($response['links'] as $links) {
                 if ($links['rel'] == 'approve') {
                     return redirect()->away($links['href']);

--- a/app/Http/Controllers/PayPalController.php
+++ b/app/Http/Controllers/PayPalController.php
@@ -92,7 +92,7 @@ class PayPalController extends Controller
                 ->first();
 
             return redirect()
-                ->route('settings.subscription', $routeOptions)
+                ->route('settings.subscription.finish', $routeOptions)
                 ->with('success', __('settings.subscription.success.subscribed'))
                 ->with('sub_tracking', $flash)
                 ->with('sub_id', $tierPrice?->id)

--- a/app/Http/Controllers/Subscription/PayPal/RenewalController.php
+++ b/app/Http/Controllers/Subscription/PayPal/RenewalController.php
@@ -20,7 +20,11 @@ class RenewalController extends Controller
     public function index(Request $request)
     {
         $user = $request->user();
-        $this->authorize('renewPaypalSubscription', $user);
+        if (!$user->can('renewPaypalSubscription', $user)) {
+            return redirect()
+            ->route('settings.subscription')
+            ->with('error', __('subscriptions/paypal-renew.errors.permission'));
+        }
 
         $tiers = Tier::ordered()->get()->reject(fn (Tier $tier) => $tier->isFree());
 
@@ -74,7 +78,7 @@ class RenewalController extends Controller
 
             return redirect()
                 ->route('settings.subscription')
-                ->with('success', __('subscriptions.renew.success'));
+                ->with('success', __('subscriptions.renew.success', ['date' => $user->subscription('kanka')->ends_at->isoFormat('MMMM D, Y')]));
         }
 
         Log::error('PayPal renewal capture error', $response);

--- a/app/Http/Controllers/Subscription/PayPal/RenewalController.php
+++ b/app/Http/Controllers/Subscription/PayPal/RenewalController.php
@@ -44,7 +44,7 @@ class RenewalController extends Controller
             ->tier($tier)
             ->process();
 
-        if (isset($response['id']) && $response['id'] !== null) {
+        if (isset($response['id'])) {
             foreach ($response['links'] as $link) {
                 if ($link['rel'] === 'approve') {
                     return redirect()->away($link['href']);

--- a/app/Http/Controllers/Subscription/PayPal/RenewalController.php
+++ b/app/Http/Controllers/Subscription/PayPal/RenewalController.php
@@ -20,10 +20,10 @@ class RenewalController extends Controller
     public function index(Request $request)
     {
         $user = $request->user();
-        if (!$user->can('renewPaypalSubscription', $user)) {
+        if (! $user->can('renewPaypalSubscription', $user)) {
             return redirect()
-            ->route('settings.subscription')
-            ->with('error', __('subscriptions/paypal-renew.errors.permission'));
+                ->route('settings.subscription')
+                ->with('error', __('subscriptions/paypal-renew.errors.permission'));
         }
 
         $tiers = Tier::ordered()->get()->reject(fn (Tier $tier) => $tier->isFree());
@@ -78,7 +78,7 @@ class RenewalController extends Controller
 
             return redirect()
                 ->route('settings.subscription')
-                ->with('success', __('subscriptions.renew.success', ['date' => $user->subscription('kanka')->ends_at->isoFormat('MMMM D, Y')]));
+                ->with('success', __('subscriptions.renew.success', ['date' => auth()->user()->subscription('kanka')->ends_at->isoFormat('MMMM D, Y')]));
         }
 
         Log::error('PayPal renewal capture error', $response);

--- a/app/Http/Controllers/Subscription/PayPal/RenewalController.php
+++ b/app/Http/Controllers/Subscription/PayPal/RenewalController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Subscription\PayPal;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ValidatePledge;
+use App\Models\Tier;
+use App\Services\Subscription\PayPalRenewalService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+
+class RenewalController extends Controller
+{
+    public function __construct(protected PayPalRenewalService $service)
+    {
+        $this->middleware(['auth', 'identity']);
+    }
+
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $this->authorize('renewPaypalSubscription', $user);
+
+        $tiers = Tier::ordered()->get()->reject(fn (Tier $tier) => $tier->isFree());
+
+        return view('settings.subscription.paypal-renew', compact('user', 'tiers'));
+    }
+
+    public function process(ValidatePledge $request, Tier $tier)
+    {
+        $this->authorize('renewPaypalSubscription', $request->user());
+
+        if ($tier->isFree()) {
+            abort(401);
+        }
+
+        $response = $this->service
+            ->user($request->user())
+            ->tier($tier)
+            ->process();
+
+        if (isset($response['id']) && $response['id'] !== null) {
+            foreach ($response['links'] as $link) {
+                if ($link['rel'] === 'approve') {
+                    return redirect()->away($link['href']);
+                }
+            }
+        }
+
+        Log::error('PayPal renewal process error', $response);
+
+        return redirect()
+            ->route('settings.subscription')
+            ->with('error', __('subscriptions/paypal.errors.failed') . ' ' . __('subscriptions/paypal.errors.contact', ['email' => config('app.email')]));
+    }
+
+    public function success(Request $request)
+    {
+        $provider = new PayPalClient;
+        $provider->setApiCredentials(config('paypal'));
+        $provider->getAccessToken();
+        $response = $provider->capturePaymentOrder($request['token']);
+
+        if (isset($response['status']) && $response['status'] === 'COMPLETED') {
+            $tierName = $response['purchase_units']['0']['reference_id'];
+            $tier = Tier::where('name', $tierName)->firstOrFail();
+
+            Log::info('PayPal renewal', $response);
+
+            $this->service
+                ->user($request->user())
+                ->renew($tier);
+
+            return redirect()
+                ->route('settings.subscription')
+                ->with('success', __('subscriptions.renew.success'));
+        }
+
+        Log::error('PayPal renewal capture error', $response);
+
+        return redirect()
+            ->route('settings.subscription')
+            ->with('error', __('subscriptions/paypal.errors.incomplete') . ' ' . __('subscriptions/paypal.errors.contact', ['email' => config('app.email')]));
+    }
+
+    public function cancel()
+    {
+        return redirect()
+            ->route('settings.subscription')
+            ->with('error', __('settings.subscription.errors.callback'));
+    }
+}

--- a/app/Jobs/Emails/Subscriptions/Admin/PaypalRenewedJob.php
+++ b/app/Jobs/Emails/Subscriptions/Admin/PaypalRenewedJob.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Jobs\Emails\Subscriptions\Admin;
+
+use App\Mail\Subscription\Admin\PaypalRenewedMail;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Mail;
+
+class PaypalRenewedJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public int $user) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $user = User::find($this->user);
+        if (! $user) {
+            return;
+        }
+
+        Mail::to('hello@kanka.io')
+            ->send(
+                new PaypalRenewedMail($user)
+            );
+    }
+}

--- a/app/Jobs/Emails/Subscriptions/PaypalExpiringAlert.php
+++ b/app/Jobs/Emails/Subscriptions/PaypalExpiringAlert.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Jobs\Emails\Subscriptions;
+
+use App\Enums\UserAction;
+use App\Mail\Subscription\User\PaypalExpiringMail;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+
+class PaypalExpiringAlert implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    protected int $userId;
+
+    public function __construct(User $user)
+    {
+        $this->userId = $user->id;
+    }
+
+    public function handle(): void
+    {
+        /** @var User|null $user */
+        $user = User::find($this->userId);
+        if (empty($user)) {
+            return;
+        }
+
+        Mail::to($user->email)
+            ->locale($user->locale)
+            ->send(new PaypalExpiringMail($user));
+
+        $user->log(UserAction::subPaypalExpiringWarning);
+    }
+}

--- a/app/Mail/Subscription/Admin/PaypalRenewedMail.php
+++ b/app/Mail/Subscription/Admin/PaypalRenewedMail.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Mail\Subscription\Admin;
+
+use App\Models\User;
+use App\Models\UserLog;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class PaypalRenewedMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public User $user;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        $action = 'Renewed';
+
+        $subject = 'Sub: ' . $action . ' Yearly ' . $this->user->pledge;
+
+        return new Envelope(
+            subject: $subject,
+            tags: ['admin-new'],
+            from: new Address(config('app.email'), 'Kanka Admin'),
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        $lastCancel = null;
+
+        /** @var ?UserLog $log */
+        $log = $this->user->logs()->whereNotNull('country')->latest()->first();
+
+        return new Content(
+            markdown: 'emails.subscriptions.new.md',
+            with: ['lastCancel' => $lastCancel, 'user' => $this->user, 'period' => 'Yearly', 'trial' => false, 'country' => $log?->country],
+        );
+    }
+}

--- a/app/Mail/Subscription/User/PaypalExpiringMail.php
+++ b/app/Mail/Subscription/User/PaypalExpiringMail.php
@@ -36,7 +36,7 @@ class PaypalExpiringMail extends Mailable
         $this->user = $user;
 
         $subscription = $user->subscription('kanka');
-        $this->expiryDate = $subscription->ends_at->isoFormat('MMMM D, Y');
+        $this->expiryDate = $subscription?->ends_at?->isoFormat('MMMM D, Y') ?? '';
         $this->renewUrl = route('paypal.renew');
 
         $this->discord = (bool) $user->discord();

--- a/app/Mail/Subscription/User/PaypalExpiringMail.php
+++ b/app/Mail/Subscription/User/PaypalExpiringMail.php
@@ -55,6 +55,7 @@ class PaypalExpiringMail extends Mailable
         $this->premiumCampaignName = $firstCampaign?->campaign?->name;
         $this->premiumCampaignCount = $premiumCampaigns->count();
 
+        /** @var Collection<int, int> $members */
         $members = new Collection;
         $this->plugins = 0;
 

--- a/app/Mail/Subscription/User/PaypalExpiringMail.php
+++ b/app/Mail/Subscription/User/PaypalExpiringMail.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Mail\Subscription\User;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class PaypalExpiringMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public User $user;
+
+    public string $expiryDate;
+
+    public ?string $premiumCampaignName;
+
+    public int $premiumCampaignCount;
+
+    public int $players;
+
+    public int $plugins;
+
+    public bool $discord;
+
+    public string $renewUrl;
+
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+
+        $subscription = $user->subscription('kanka');
+        $this->expiryDate = $subscription->ends_at->isoFormat('MMMM D, Y');
+        $this->renewUrl = route('paypal.renew');
+
+        $this->discord = (bool) $user->discord();
+
+        /** @var Collection $premiumCampaigns */
+        $premiumCampaigns = $user->boosts()
+            ->with([
+                'campaign' => fn ($sub) => $sub->select('campaigns.id', 'campaigns.name'),
+                'campaign.members',
+                'campaign.plugins',
+            ])
+            ->groupBy('campaign_id')
+            ->get();
+
+        $firstCampaign = $premiumCampaigns->first();
+        $this->premiumCampaignName = $firstCampaign?->campaign?->name;
+        $this->premiumCampaignCount = $premiumCampaigns->count();
+
+        $members = new Collection;
+        $this->plugins = 0;
+
+        if ($firstCampaign) {
+            foreach ($firstCampaign->campaign->members as $member) {
+                $members->push($member->user_id);
+            }
+            $this->plugins = $firstCampaign->campaign->plugins->count();
+        }
+
+        $this->players = $members->unique()->reject(fn ($userId) => $userId === $user->id)->count();
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('emails/subscriptions/paypal-expiring.title'),
+            tags: ['user', 'paypal-expiring'],
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.subscriptions.paypal-expiring.user',
+        );
+    }
+}

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -25,7 +25,7 @@ class UserPolicy
         return session()->get('kanka.freeTrial') && ! $user->isSubscriber();
     }
 
-    public function renewPaypalSubscription(User $_authUser, User $user): bool
+    public function renewPaypalSubscription(User $user): bool
     {
         if (! $user->hasPayPal()) {
             return false;

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -25,7 +25,7 @@ class UserPolicy
         return session()->get('kanka.freeTrial') && ! $user->isSubscriber();
     }
 
-    public function renewPaypalSubscription(User $authUser, User $user): bool
+    public function renewPaypalSubscription(User $_authUser, User $user): bool
     {
         if (! $user->hasPayPal()) {
             return false;

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -24,4 +24,18 @@ class UserPolicy
     {
         return session()->get('kanka.freeTrial') && ! $user->isSubscriber();
     }
+
+    public function renewPaypalSubscription(User $authUser, User $user): bool
+    {
+        if (! $user->hasPayPal()) {
+            return false;
+        }
+
+        $subscription = $user->subscription('kanka');
+        if (! $subscription) {
+            return false;
+        }
+
+        return $subscription->ends_at->lte(now()->addDays(14));
+    }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -36,6 +36,6 @@ class UserPolicy
             return false;
         }
 
-        return $subscription->ends_at->lte(now()->addDays(14));
+        return $subscription->ends_at->lte(now()->addDays(15));
     }
 }

--- a/app/Services/Subscription/PayPalRenewalService.php
+++ b/app/Services/Subscription/PayPalRenewalService.php
@@ -54,6 +54,7 @@ class PayPalRenewalService
 
     public function renew(Tier $tier): void
     {
+        /** @var \Laravel\Cashier\Subscription $sub */
         $sub = $this->user->subscriptions()->where('stripe_price', 'like', 'paypal_%')->first();
         $sub->ends_at = $sub->ends_at->addYear();
         $sub->stripe_price = 'paypal_' . $tier->name;

--- a/app/Services/Subscription/PayPalRenewalService.php
+++ b/app/Services/Subscription/PayPalRenewalService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Subscription;
 
 use App\Enums\UserAction;
+use App\Jobs\Emails\Subscriptions\Admin\PaypalRenewedJob;
 use App\Models\Tier;
 use App\Traits\UserAware;
 use Srmklive\PayPal\Services\PayPal;
@@ -62,5 +63,7 @@ class PayPalRenewalService
         $this->user->save();
 
         $this->user->log(UserAction::subPaypalRenew);
+        
+        PaypalRenewedJob::dispatch($this->user->id);
     }
 }

--- a/app/Services/Subscription/PayPalRenewalService.php
+++ b/app/Services/Subscription/PayPalRenewalService.php
@@ -6,6 +6,7 @@ use App\Enums\UserAction;
 use App\Jobs\Emails\Subscriptions\Admin\PaypalRenewedJob;
 use App\Models\Tier;
 use App\Traits\UserAware;
+use Laravel\Cashier\Subscription;
 use Srmklive\PayPal\Services\PayPal;
 
 class PayPalRenewalService
@@ -54,7 +55,7 @@ class PayPalRenewalService
 
     public function renew(Tier $tier): void
     {
-        /** @var \Laravel\Cashier\Subscription $sub */
+        /** @var Subscription $sub */
         $sub = $this->user->subscriptions()->where('stripe_price', 'like', 'paypal_%')->first();
         $sub->ends_at = $sub->ends_at->addYear();
         $sub->stripe_price = 'paypal_' . $tier->name;

--- a/app/Services/Subscription/PayPalRenewalService.php
+++ b/app/Services/Subscription/PayPalRenewalService.php
@@ -63,7 +63,7 @@ class PayPalRenewalService
         $this->user->save();
 
         $this->user->log(UserAction::subPaypalRenew);
-        
+
         PaypalRenewedJob::dispatch($this->user->id);
     }
 }

--- a/app/Services/Subscription/PayPalRenewalService.php
+++ b/app/Services/Subscription/PayPalRenewalService.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Services\Subscription;
+
+use App\Enums\UserAction;
+use App\Models\Tier;
+use App\Traits\UserAware;
+use Srmklive\PayPal\Services\PayPal;
+
+class PayPalRenewalService
+{
+    use UserAware;
+
+    protected Tier $tier;
+
+    public function tier(Tier $tier): self
+    {
+        $this->tier = $tier;
+
+        return $this;
+    }
+
+    public function process(): mixed
+    {
+        $currency = 'USD';
+        if ($this->user->billedInEur()) {
+            $currency = 'EUR';
+        }
+
+        $price = $this->tier->yearly;
+
+        $provider = new PayPal;
+        $provider->setApiCredentials(config('paypal'));
+        $provider->getAccessToken();
+
+        return $provider->createOrder([
+            'intent' => 'CAPTURE',
+            'application_context' => [
+                'return_url' => route('paypal.renew-success'),
+                'cancel_url' => route('paypal.renew-cancel'),
+            ],
+            'purchase_units' => [
+                0 => [
+                    'reference_id' => $this->tier->name,
+                    'amount' => [
+                        'currency_code' => $currency,
+                        'value' => $price,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function renew(Tier $tier): void
+    {
+        $sub = $this->user->subscriptions()->first();
+        $sub->ends_at = $sub->ends_at->addYear();
+        $sub->stripe_price = 'paypal_' . $tier->code;
+        $sub->save();
+
+        $this->user->pledge = $tier->name;
+        $this->user->save();
+
+        $this->user->log(UserAction::subPaypalRenew);
+    }
+}

--- a/app/Services/Subscription/PayPalRenewalService.php
+++ b/app/Services/Subscription/PayPalRenewalService.php
@@ -53,9 +53,9 @@ class PayPalRenewalService
 
     public function renew(Tier $tier): void
     {
-        $sub = $this->user->subscriptions()->first();
+        $sub = $this->user->subscriptions()->where('stripe_price', 'like', 'paypal_%')->first();
         $sub->ends_at = $sub->ends_at->addYear();
-        $sub->stripe_price = 'paypal_' . $tier->code;
+        $sub->stripe_price = 'paypal_' . $tier->name;
         $sub->save();
 
         $this->user->pledge = $tier->name;

--- a/docs/superpowers/plans/2026-04-08-paypal-expiry-renewal.md
+++ b/docs/superpowers/plans/2026-04-08-paypal-expiry-renewal.md
@@ -1,0 +1,911 @@
+# PayPal Expiry Reminder & Renewal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Send PayPal subscribers a 2-week expiry reminder email with a "what you'll lose" breakdown, and provide a dedicated renewal flow that extends `ends_at` by one year from the current expiry date (with optional tier upgrade).
+
+**Architecture:** A new Artisan command dispatches a queued email job daily for users whose PayPal subscription expires in exactly 14 days. A new `PayPalRenewalService` handles the PayPal order and extends `ends_at = old_ends_at + 1 year`. A new `RenewalController` provides four routes. A `UserPolicy` method gates access, and a banner on the subscription settings page surfaces the renewal option in-app.
+
+**Tech Stack:** Laravel 11, Laravel Cashier (Subscription model), `srmklive/paypal`, Blade markdown mail, Artisan scheduler
+
+---
+
+## File Map
+
+| File | Action |
+|---|---|
+| `app/Enums/UserAction.php` | Edit — add `subPaypalExpiringWarning = 84` and `subPaypalRenew = 85` |
+| `app/Console/Commands/Subscriptions/PaypalExpiringCommand.php` | Create |
+| `app/Console/Kernel.php` | Edit — register daily schedule |
+| `app/Jobs/Emails/Subscriptions/PaypalExpiringAlert.php` | Create |
+| `app/Mail/Subscription/User/PaypalExpiringMail.php` | Create |
+| `lang/en/emails/subscriptions/paypal-expiring.php` | Create |
+| `resources/views/emails/subscriptions/paypal-expiring/user.blade.php` | Create |
+| `app/Services/Subscription/PayPalRenewalService.php` | Create |
+| `app/Http/Controllers/Subscription/PayPal/RenewalController.php` | Create |
+| `routes/settings.php` | Edit — add 4 PayPal renewal routes |
+| `resources/views/settings/subscription/paypal-renew.blade.php` | Create |
+| `app/Policies/UserPolicy.php` | Edit — add `renewPaypalSubscription` method |
+| `resources/views/settings/subscription/index.blade.php` | Edit — add renewal banner |
+
+---
+
+## Task 1: Add UserAction enum cases
+
+**Files:**
+- Modify: `app/Enums/UserAction.php`
+
+- [ ] **Step 1: Add the two new cases**
+
+Open `app/Enums/UserAction.php`. After line `case yearlyRenewWarning = 81;`, add:
+
+```php
+    case subPaypalExpiringWarning = 84;
+    case subPaypalRenew = 85;
+```
+
+The block around it should look like:
+
+```php
+    case failedChargeEmail = 80;
+    case yearlyRenewWarning = 81;
+    case subCancelManual = 82;
+    case subCancelAuto = 83;
+    case subPaypalExpiringWarning = 84;
+    case subPaypalRenew = 85;
+    case paymentEdit = 86;
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Enums/UserAction.php
+git commit -m "feat: add PayPal expiry warning and renewal UserAction cases"
+```
+
+---
+
+## Task 2: Artisan command — PaypalExpiringCommand
+
+**Files:**
+- Create: `app/Console/Commands/Subscriptions/PaypalExpiringCommand.php`
+
+- [ ] **Step 1: Create the file**
+
+```php
+<?php
+
+namespace App\Console\Commands\Subscriptions;
+
+use App\Jobs\Emails\Subscriptions\PaypalExpiringAlert;
+use App\Models\User;
+use App\Traits\HasJobLog;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class PaypalExpiringCommand extends Command
+{
+    use HasJobLog;
+
+    protected $signature = 'subscriptions:paypal-expiring';
+
+    protected $description = 'Alert PayPal subscribers whose subscription expires in 14 days';
+
+    protected int $count = 0;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $target = Carbon::now()->addDays(14)->toDateString();
+        $log = "Looking for PayPal subscriptions expiring on {$target}";
+        $this->info($log);
+
+        User::whereHas('subscriptions', function ($query) use ($target): void {
+            $query->where('stripe_price', 'like', 'paypal_%')
+                ->whereDate('ends_at', $target);
+        })
+            ->chunk(100, function ($users): void {
+                foreach ($users as $user) {
+                    $this->notify($user);
+                }
+            });
+
+        $this->info('Alerted ' . $this->count . ' subscribers.');
+        $log .= '<br />' . 'Alerted ' . $this->count . ' subscribers.';
+
+        $this->log($log);
+
+        return 0;
+    }
+
+    protected function notify(User $user): void
+    {
+        if (! $user->subscribed('kanka')) {
+            return;
+        }
+
+        PaypalExpiringAlert::dispatch($user);
+        $this->count++;
+    }
+}
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Console/Commands/Subscriptions/PaypalExpiringCommand.php
+git commit -m "feat: add PaypalExpiringCommand to alert expiring PayPal subscribers"
+```
+
+---
+
+## Task 3: Register the command in the scheduler
+
+**Files:**
+- Modify: `app/Console/Kernel.php`
+
+- [ ] **Step 1: Add the import**
+
+At the top of `app/Console/Kernel.php`, add alongside the other subscription command imports:
+
+```php
+use App\Console\Commands\Subscriptions\PaypalExpiringCommand;
+```
+
+- [ ] **Step 2: Register the schedule**
+
+Inside `protected function schedule(Schedule $schedule): void`, add after the `EndFreeTrials` line:
+
+```php
+$schedule->command(PaypalExpiringCommand::class)->onOneServer()->dailyAt('06:30')->sentryMonitor();
+```
+
+- [ ] **Step 3: Format**
+
+```bash
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/Console/Kernel.php
+git commit -m "feat: schedule PaypalExpiringCommand daily at 06:30"
+```
+
+---
+
+## Task 4: Email job — PaypalExpiringAlert
+
+**Files:**
+- Create: `app/Jobs/Emails/Subscriptions/PaypalExpiringAlert.php`
+
+- [ ] **Step 1: Create the file**
+
+```php
+<?php
+
+namespace App\Jobs\Emails\Subscriptions;
+
+use App\Enums\UserAction;
+use App\Mail\Subscription\User\PaypalExpiringMail;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+
+class PaypalExpiringAlert implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    protected int $userId;
+
+    public function __construct(User $user)
+    {
+        $this->userId = $user->id;
+    }
+
+    public function handle(): void
+    {
+        /** @var User|null $user */
+        $user = User::find($this->userId);
+        if (empty($user)) {
+            return;
+        }
+
+        Mail::to($user->email)
+            ->locale($user->locale)
+            ->send(new PaypalExpiringMail($user));
+
+        $user->log(UserAction::subPaypalExpiringWarning);
+    }
+}
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Jobs/Emails/Subscriptions/PaypalExpiringAlert.php
+git commit -m "feat: add PaypalExpiringAlert queued email job"
+```
+
+---
+
+## Task 5: Translation keys for the expiry email
+
+**Files:**
+- Create: `lang/en/emails/subscriptions/paypal-expiring.php`
+
+- [ ] **Step 1: Create the file**
+
+```php
+<?php
+
+return [
+    'title'   => 'Your Kanka subscription expires soon',
+    'dear'    => 'Dear :name',
+    'intro'   => 'Your Kanka PayPal subscription expires on **:date**. After that date your account will revert to the free tier.',
+    'loss'    => [
+        'title'   => 'Here is what you will lose:',
+        'campaign' => 'Premium campaign **:campaign**|Premium campaigns **:campaign** and :count more',
+        'players'  => ':count player will lose access|:count players will lose access',
+        'plugins'  => ':count marketplace plugin|:count marketplace plugins',
+        'ads'      => 'Ad-free experience',
+        'discord'  => 'Your **:role** Discord role',
+    ],
+    'cta'     => 'Renew your subscription',
+    'closing' => 'Yours truly,',
+];
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add lang/en/emails/subscriptions/paypal-expiring.php
+git commit -m "feat: add translation keys for PayPal expiry reminder email"
+```
+
+---
+
+## Task 6: Email mailable — PaypalExpiringMail
+
+**Files:**
+- Create: `app/Mail/Subscription/User/PaypalExpiringMail.php`
+
+- [ ] **Step 1: Create the file**
+
+The constructor gathers "what you'll lose" data the same way `CancellationController::index()` does, so the template receives pre-computed variables.
+
+```php
+<?php
+
+namespace App\Mail\Subscription\User;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class PaypalExpiringMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public User $user;
+
+    public string $expiryDate;
+
+    public ?string $premiumCampaignName;
+
+    public int $premiumCampaignCount;
+
+    public int $players;
+
+    public int $plugins;
+
+    public bool $discord;
+
+    public string $renewUrl;
+
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+
+        $subscription = $user->subscription('kanka');
+        $this->expiryDate = $subscription->ends_at->isoFormat('MMMM D, Y');
+        $this->renewUrl = route('paypal.renew');
+
+        $this->discord = (bool) $user->discord();
+
+        /** @var Collection $premiumCampaigns */
+        $premiumCampaigns = $user->boosts()
+            ->with([
+                'campaign' => fn ($sub) => $sub->select('campaigns.id', 'campaigns.name'),
+                'campaign.members',
+                'campaign.plugins',
+            ])
+            ->groupBy('campaign_id')
+            ->get();
+
+        $firstCampaign = $premiumCampaigns->first();
+        $this->premiumCampaignName = $firstCampaign?->campaign?->name;
+        $this->premiumCampaignCount = $premiumCampaigns->count();
+
+        $members = new Collection;
+        $this->plugins = 0;
+
+        if ($firstCampaign) {
+            foreach ($firstCampaign->campaign->members as $member) {
+                $members->push($member->user_id);
+            }
+            $this->plugins = $firstCampaign->campaign->plugins->count();
+        }
+
+        $this->players = $members->unique()->reject(fn ($userId) => $userId === $user->id)->count();
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('emails/subscriptions/paypal-expiring.title'),
+            tags: ['user', 'paypal-expiring'],
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.subscriptions.paypal-expiring.user',
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Mail/Subscription/User/PaypalExpiringMail.php
+git commit -m "feat: add PaypalExpiringMail mailable with loss data"
+```
+
+---
+
+## Task 7: Email Blade template
+
+**Files:**
+- Create: `resources/views/emails/subscriptions/paypal-expiring/user.blade.php`
+
+- [ ] **Step 1: Create the file**
+
+```blade
+<x-mail::message>
+
+{{ __('emails/subscriptions/paypal-expiring.dear', ['name' => $user->name]) }},
+
+{{ __('emails/subscriptions/paypal-expiring.intro', ['date' => $expiryDate]) }}
+
+{{ __('emails/subscriptions/paypal-expiring.loss.title') }}
+
+@if ($premiumCampaignName)
+- {{ trans_choice('emails/subscriptions/paypal-expiring.loss.campaign', $premiumCampaignCount - 1, ['campaign' => $premiumCampaignName, 'count' => $premiumCampaignCount - 1]) }}
+@if ($players > 0)
+  - {{ trans_choice('emails/subscriptions/paypal-expiring.loss.players', $players, ['count' => $players]) }}
+@endif
+@if ($plugins > 0)
+  - {{ trans_choice('emails/subscriptions/paypal-expiring.loss.plugins', $plugins, ['count' => $plugins]) }}
+@endif
+@endif
+- {{ __('emails/subscriptions/paypal-expiring.loss.ads') }}
+@if ($discord)
+- {{ __('emails/subscriptions/paypal-expiring.loss.discord', ['role' => $user->pledge]) }}
+@endif
+
+<x-mail::button :url="$renewUrl">
+{{ __('emails/subscriptions/paypal-expiring.cta') }}
+</x-mail::button>
+
+{{ __('emails/subscriptions/paypal-expiring.closing') }}
+
+__Jay & Jon_
+
+</x-mail::message>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add resources/views/emails/subscriptions/paypal-expiring/user.blade.php
+git commit -m "feat: add PayPal expiry reminder email template"
+```
+
+---
+
+## Task 8: PayPalRenewalService
+
+**Files:**
+- Create: `app/Services/Subscription/PayPalRenewalService.php`
+
+- [ ] **Step 1: Create the file**
+
+```php
+<?php
+
+namespace App\Services\Subscription;
+
+use App\Enums\UserAction;
+use App\Models\Tier;
+use App\Traits\UserAware;
+use Srmklive\PayPal\Services\PayPal;
+
+class PayPalRenewalService
+{
+    use UserAware;
+
+    protected Tier $tier;
+
+    public function tier(Tier $tier): self
+    {
+        $this->tier = $tier;
+
+        return $this;
+    }
+
+    public function process(): mixed
+    {
+        $currency = 'USD';
+        if ($this->user->billedInEur()) {
+            $currency = 'EUR';
+        }
+
+        $price = $this->tier->yearly;
+
+        $provider = new PayPal;
+        $provider->setApiCredentials(config('paypal'));
+        $provider->getAccessToken();
+
+        return $provider->createOrder([
+            'intent' => 'CAPTURE',
+            'application_context' => [
+                'return_url' => route('paypal.renew-success'),
+                'cancel_url' => route('paypal.renew-cancel'),
+            ],
+            'purchase_units' => [
+                0 => [
+                    'reference_id' => $this->tier->name,
+                    'amount' => [
+                        'currency_code' => $currency,
+                        'value' => $price,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function renew(Tier $tier): void
+    {
+        $sub = $this->user->subscriptions()->first();
+        $sub->ends_at = $sub->ends_at->addYear();
+        $sub->stripe_price = 'paypal_' . $tier->code;
+        $sub->save();
+
+        $this->user->pledge = $tier->name;
+        $this->user->save();
+
+        $this->user->log(UserAction::subPaypalRenew);
+    }
+}
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Services/Subscription/PayPalRenewalService.php
+git commit -m "feat: add PayPalRenewalService with process and renew methods"
+```
+
+---
+
+## Task 9: Routes
+
+**Files:**
+- Modify: `routes/settings.php`
+
+- [ ] **Step 1: Add the import at the top of the file**
+
+Open `routes/settings.php`. Find the existing `use App\Http\Controllers\PayPalController;` import and add below it:
+
+```php
+use App\Http\Controllers\Subscription\PayPal\RenewalController;
+```
+
+- [ ] **Step 2: Add routes after the existing PayPal block**
+
+Find the existing PayPal routes block (around line 173–178). Directly after it, add:
+
+```php
+/*
+--------------------------------------------------------------------------
+PayPal Renewal
+--------------------------------------------------------------------------
+*/
+
+Route::get('subscription/paypal/renew', [RenewalController::class, 'index'])
+    ->name('paypal.renew');
+Route::post('subscription/paypal/renew/{tier}', [RenewalController::class, 'process'])
+    ->name('paypal.renew-process');
+Route::get('subscription/paypal/renew/success', [RenewalController::class, 'success'])
+    ->name('paypal.renew-success');
+Route::get('subscription/paypal/renew/cancel', [RenewalController::class, 'cancel'])
+    ->name('paypal.renew-cancel');
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add routes/settings.php
+git commit -m "feat: add PayPal renewal routes"
+```
+
+---
+
+## Task 10: RenewalController
+
+**Files:**
+- Create: `app/Http/Controllers/Subscription/PayPal/RenewalController.php`
+
+- [ ] **Step 1: Create the file**
+
+```php
+<?php
+
+namespace App\Http\Controllers\Subscription\PayPal;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ValidatePledge;
+use App\Models\Tier;
+use App\Services\Subscription\PayPalRenewalService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+
+class RenewalController extends Controller
+{
+    public function __construct(protected PayPalRenewalService $service)
+    {
+        $this->middleware(['auth', 'identity']);
+    }
+
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $this->authorize('renewPaypalSubscription', $user);
+
+        $tiers = Tier::ordered()->get()->reject(fn (Tier $tier) => $tier->isFree());
+
+        return view('settings.subscription.paypal-renew', compact('user', 'tiers'));
+    }
+
+    public function process(ValidatePledge $request, Tier $tier)
+    {
+        $this->authorize('renewPaypalSubscription', $request->user());
+
+        if ($tier->isFree()) {
+            abort(401);
+        }
+
+        $response = $this->service
+            ->user($request->user())
+            ->tier($tier)
+            ->process();
+
+        if (isset($response['id']) && $response['id'] !== null) {
+            foreach ($response['links'] as $link) {
+                if ($link['rel'] === 'approve') {
+                    return redirect()->away($link['href']);
+                }
+            }
+        }
+
+        Log::error('PayPal renewal process error', $response);
+
+        return redirect()
+            ->route('settings.subscription')
+            ->with('error', __('subscriptions/paypal.errors.failed') . ' ' . __('subscriptions/paypal.errors.contact', ['email' => config('app.email')]));
+    }
+
+    public function success(Request $request)
+    {
+        $provider = new PayPalClient;
+        $provider->setApiCredentials(config('paypal'));
+        $provider->getAccessToken();
+        $response = $provider->capturePaymentOrder($request['token']);
+
+        if (isset($response['status']) && $response['status'] === 'COMPLETED') {
+            $tierName = $response['purchase_units']['0']['reference_id'];
+            $tier = Tier::where('name', $tierName)->firstOrFail();
+
+            Log::info('PayPal renewal', $response);
+
+            $this->service
+                ->user($request->user())
+                ->renew($tier);
+
+            return redirect()
+                ->route('settings.subscription')
+                ->with('success', __('subscriptions.renew.success'));
+        }
+
+        Log::error('PayPal renewal capture error', $response);
+
+        return redirect()
+            ->route('settings.subscription')
+            ->with('error', __('subscriptions/paypal.errors.incomplete') . ' ' . __('subscriptions/paypal.errors.contact', ['email' => config('app.email')]));
+    }
+
+    public function cancel()
+    {
+        return redirect()
+            ->route('settings.subscription')
+            ->with('error', __('settings.subscription.errors.callback'));
+    }
+}
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Http/Controllers/Subscription/PayPal/RenewalController.php
+git commit -m "feat: add PayPal RenewalController"
+```
+
+---
+
+## Task 11: Renewal view
+
+**Files:**
+- Create: `resources/views/settings/subscription/paypal-renew.blade.php`
+
+- [ ] **Step 1: Create the file**
+
+```blade
+<?php
+/**
+ * @var \App\Models\User $user
+ * @var \Illuminate\Database\Eloquent\Collection|\App\Models\Tier[] $tiers
+ */
+?>
+@extends('layouts.app', [
+    'title' => __('subscriptions/renew.title'),
+    'breadcrumbs' => false,
+    'sidebar' => 'settings',
+    'centered' => true,
+])
+
+@section('content')
+<x-grid type="1/1">
+    <h1 class="text-2xl">{{ __('subscriptions/renew.title') }}</h1>
+
+    <x-helper>
+        <p>
+            {!! __('subscriptions/paypal-renew.intro', [
+                'date' => '<strong>' . $user->subscription('kanka')->ends_at->isoFormat('MMMM D, Y') . '</strong>',
+            ]) !!}
+        </p>
+    </x-helper>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        @foreach ($tiers as $tier)
+            <article class="rounded-2xl bg-box flex flex-col gap-4 p-4 relative shadow-xs hover:shadow-md @if ($tier->isCurrent($user)) border-primary border @endif">
+                <div class="flex gap-2 items-center">
+                    <img src="{{ $tier->image() }}" alt="{{ $tier->name }}" class="w-10 h-10" />
+                    <h2 class="text-xl m-0">{{ $tier->name }}</h2>
+                    @if ($tier->isCurrent($user))
+                        <span class="badge badge-primary badge-sm">{{ __('tiers.current') }}</span>
+                    @endif
+                </div>
+
+                @include('settings.subscription.tiers.benefits._' . strtolower($tier->name))
+
+                @if (!$user->isElemental() || !$tier->isCurrent($user))
+                    @php
+                        $isDowngrade = match($user->pledge) {
+                            'Elemental' => in_array($tier->name, ['Owlbear', 'Wyvern']),
+                            'Wyvern'    => $tier->name === 'Owlbear',
+                            default     => false,
+                        };
+                    @endphp
+
+                    @if (!$isDowngrade)
+                        <x-form :action="['paypal.renew-process', 'tier' => $tier]" class="mt-auto">
+                            <x-buttons.confirm type="primary" class="btn-block">
+                                {{ $tier->isCurrent($user)
+                                    ? __('subscriptions/renew.actions.renew')
+                                    : __('tiers.actions.subscribe.upgrade', ['tier' => $tier->name]) }}
+                            </x-buttons.confirm>
+                        </x-form>
+                    @endif
+                @endif
+            </article>
+        @endforeach
+    </div>
+</x-grid>
+@endsection
+```
+
+- [ ] **Step 2: Add the translation file for the renewal page**
+
+Create `lang/en/subscriptions/paypal-renew.php`:
+
+```php
+<?php
+
+return [
+    'intro' => 'Your subscription expires on :date. Renewing will extend your access for one full year from that date.',
+];
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/views/settings/subscription/paypal-renew.blade.php lang/en/subscriptions/paypal-renew.php
+git commit -m "feat: add PayPal renewal page view and translations"
+```
+
+---
+
+## Task 12: UserPolicy — renewPaypalSubscription
+
+**Files:**
+- Modify: `app/Policies/UserPolicy.php`
+
+- [ ] **Step 1: Add the method**
+
+Open `app/Policies/UserPolicy.php` and add the method after the `freeTrial` method:
+
+```php
+    public function renewPaypalSubscription(User $authUser, User $user): bool
+    {
+        if (! $user->hasPayPal()) {
+            return false;
+        }
+
+        $subscription = $user->subscription('kanka');
+        if (! $subscription) {
+            return false;
+        }
+
+        return $subscription->ends_at->lte(now()->addDays(14));
+    }
+```
+
+`lte(now()->addDays(14))` returns true when `ends_at` is within the next 14 days (or already in the past).
+
+- [ ] **Step 2: Format**
+
+```bash
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Policies/UserPolicy.php
+git commit -m "feat: add renewPaypalSubscription policy method to UserPolicy"
+```
+
+---
+
+## Task 13: Subscription settings page — renewal banner
+
+**Files:**
+- Modify: `resources/views/settings/subscription/index.blade.php`
+
+- [ ] **Step 1: Add the banner**
+
+Open `resources/views/settings/subscription/index.blade.php`. Find the line:
+
+```blade
+        @include('partials.errors')
+```
+
+Add the following block directly after it:
+
+```blade
+        @can('renewPaypalSubscription', $user)
+            <x-alert type="warning">
+                <p class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <span>
+                        {!! __('settings.subscription.paypal_expiring', [
+                            'date' => '<strong>' . $user->subscription('kanka')->ends_at->isoFormat('MMMM D, Y') . '</strong>',
+                        ]) !!}
+                    </span>
+                    <a href="{{ route('paypal.renew') }}" class="btn2 btn-warning btn-sm whitespace-nowrap">
+                        {{ __('subscriptions/renew.actions.renew') }}
+                    </a>
+                </p>
+            </x-alert>
+        @endcan
+```
+
+- [ ] **Step 2: Add the translation key**
+
+Open `lang/en/settings.php`. Find the `'subscription' => [` array. Add inside it:
+
+```php
+'paypal_expiring' => 'Your PayPal subscription expires on :date. Renew now to avoid losing access.',
+```
+
+- [ ] **Step 3: Format**
+
+```bash
+vendor/bin/sail bin pint --dirty --format agent
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/views/settings/subscription/index.blade.php lang/en/settings.php
+git commit -m "feat: add PayPal expiry renewal banner to subscription settings page"
+```
+
+---
+
+## Done
+
+All four features are now in place:
+
+1. `subscriptions:paypal-expiring` runs daily and dispatches `PaypalExpiringAlert` for users expiring in 14 days
+2. `PaypalExpiringMail` sends a personalised email with loss details and a renewal CTA
+3. The PayPal renewal flow (`/subscription/paypal/renew`) lets users extend by one year from their current `ends_at`, with optional tier upgrade
+4. The subscription settings page shows a `x-alert` banner during the 2-week window, gated by `UserPolicy::renewPaypalSubscription`
+
+> **Reminder:** Run `vendor/bin/sail yarn run build` or `vendor/bin/sail composer run dev` so the frontend picks up any asset changes.

--- a/docs/superpowers/specs/2026-04-08-paypal-expiry-renewal-design.md
+++ b/docs/superpowers/specs/2026-04-08-paypal-expiry-renewal-design.md
@@ -1,0 +1,147 @@
+# PayPal Subscription Expiry Reminder & Renewal — Design Spec
+
+**Date:** 2026-04-08
+**Status:** Approved
+
+## Overview
+
+PayPal subscribers receive a one-year, non-auto-renewing subscription. This feature adds:
+
+1. A 2-week expiry reminder email with "what you'll lose" detail and a renewal CTA
+2. A dedicated PayPal renewal flow allowing users to buy an extra year (with optional tier upgrade)
+3. A warning banner on the subscription settings page during the 2-week window
+4. A `UserPolicy` method gating access to the renewal flow
+
+---
+
+## Section 1: Artisan Command
+
+**File:** `app/Console/Commands/Subscriptions/PaypalExpiringCommand.php`
+**Signature:** `subscriptions:paypal-expiring`
+**Schedule:** Daily in `app/Console/Kernel.php` (with Sentry monitoring, consistent with `EndSubscriptions`)
+
+Finds all users with a PayPal subscription (`stripe_price LIKE 'paypal_%'`) whose `ends_at` falls exactly 14 days from today. Chunks results and dispatches a `PaypalExpiringAlert` job per user. Uses the `HasJobLog` trait and chunk pattern consistent with `ExpiringCardCommand`.
+
+---
+
+## Section 2: Email
+
+### Job
+**File:** `app/Jobs/Emails/Subscriptions/PaypalExpiringAlert.php`
+
+Follows the same structure as `UpcomingYearlyAlert`: stores user ID, re-fetches in `handle()`, bails if user deleted, sends the mailable with the user's locale, logs `UserAction::subPaypalExpiringWarning`.
+
+### Mailable
+**File:** `app/Mail/Subscription/User/PaypalExpiringMail.php`
+
+Constructor gathers the same loss data as `CancellationController::index()`:
+- Premium campaign name + player count + plugin count (from `$user->boosts()` relation)
+- Discord connection status
+- Expiry date (`$subscription->ends_at`)
+- Renewal URL (`route('paypal.renew')`)
+
+Passes all data to the Blade template. Uses tags `['user', 'paypal-expiring']`.
+
+### Template
+**File:** `resources/views/emails/subscriptions/paypal-expiring/user.blade.php`
+
+Markdown mail. Content:
+- **Subject:** translated via `emails/subscriptions/paypal-expiring.title`
+- Body: expiry date, bulleted list of what will be lost (campaign boosts with player/plugin counts if applicable, ad-free experience, Discord role if connected)
+- CTA button linking to `paypal.renew`
+
+Translation keys live under `lang/*/emails/subscriptions/paypal-expiring.php`.
+
+### Enum
+Add `subPaypalExpiringWarning` case to `app/Enums/UserAction.php` (consistent with `yearlyRenewWarning = 81`).
+
+---
+
+## Section 3: Renewal Flow
+
+### Service
+**File:** `app/Services/PayPalRenewalService.php`
+
+Uses the `UserAware` trait. Two public methods:
+
+**`process(): mixed`**
+- Resolves currency from `$user->billedInEur()`
+- Charges the full yearly tier price (no proration — this is a clean new year)
+- Creates a PayPal order with `return_url = paypal.renew-success`, `cancel_url = paypal.renew-cancel`
+- `reference_id` = tier name (same pattern as `PayPalService`)
+
+**`renew(string $pledge): void`**
+- Loads the user's existing PayPal subscription via `$user->subscriptions()->first()`
+- Sets `ends_at = old_ends_at->addYear()`
+- Updates `stripe_price = 'paypal_' . $pledge`
+- Updates `user->pledge = $pledge`
+- Saves both records
+- Logs `UserAction::subPaypalRenew`
+
+### Controller
+**File:** `app/Http/Controllers/PayPalRenewalController.php`
+
+Middleware: `['auth', 'identity']`
+
+| Method | Route | Description |
+|---|---|---|
+| `index()` | `GET paypal.renew` | Shows renewal page; authorises via `UserPolicy::renewPaypalSubscription` |
+| `processRenewal(ValidatePledge, Tier)` | `POST paypal.renew-process` | Calls `PayPalRenewalService::process()`, redirects to PayPal approval URL |
+| `successRenewal(Request)` | `GET paypal.renew-success` | Captures payment order, calls `renew($pledge)`, redirects to `settings.subscription` with success flash |
+| `cancelRenewal()` | `GET paypal.renew-cancel` | Redirects to `settings.subscription` with error flash |
+
+### Routes
+Added alongside existing PayPal routes in `routes/settings.php`:
+
+```
+GET  /subscription/paypal/renew              paypal.renew
+POST /subscription/paypal/renew/{tier}       paypal.renew-process
+GET  /subscription/paypal/renew/success      paypal.renew-success
+GET  /subscription/paypal/renew/cancel       paypal.renew-cancel
+```
+
+### View
+**File:** `resources/views/settings/subscription/paypal-renew.blade.php`
+
+Tier picker pre-selected on user's current tier. Allows upgrading to a higher tier; does not allow downgrading (they are buying a full new year at the chosen tier). Reuses existing tier benefit partials where possible. PayPal button per eligible tier posts to `paypal.renew-process`.
+
+### Enum
+Add `subPaypalRenew` case to `app/Enums/UserAction.php`.
+
+---
+
+## Section 4: Settings Page Banner & Policy
+
+### Policy Method
+**File:** `app/Policies/UserPolicy.php` (existing)
+
+Add method `renewPaypalSubscription(User $authUser, User $user): bool`:
+- User must have a PayPal subscription (`$user->hasPayPal()`)
+- Subscription `ends_at` must be within 14 days from now
+
+Both the banner and `PayPalRenewalController::index()` authorise against this policy method. Controller aborts 403 if unauthorised.
+
+### Banner
+**File:** `resources/views/settings/subscription/index.blade.php`
+
+Add `@can('renewPaypalSubscription', $user)` block rendering a warning helper banner showing the expiry date and a button linking to `paypal.renew`. Positioned prominently (above tier cards).
+
+---
+
+## File Summary
+
+| File | Action |
+|---|---|
+| `app/Console/Commands/Subscriptions/PaypalExpiringCommand.php` | New |
+| `app/Console/Kernel.php` | Edit — register daily schedule |
+| `app/Jobs/Emails/Subscriptions/PaypalExpiringAlert.php` | New |
+| `app/Mail/Subscription/User/PaypalExpiringMail.php` | New |
+| `resources/views/emails/subscriptions/paypal-expiring/user.blade.php` | New |
+| `lang/*/emails/subscriptions/paypal-expiring.php` | New |
+| `app/Enums/UserAction.php` | Edit — add two cases |
+| `app/Services/PayPalRenewalService.php` | New |
+| `app/Http/Controllers/PayPalRenewalController.php` | New |
+| `routes/settings.php` | Edit — add 4 routes |
+| `resources/views/settings/subscription/paypal-renew.blade.php` | New |
+| `app/Policies/UserPolicy.php` | Edit — add policy method |
+| `resources/views/settings/subscription/index.blade.php` | Edit — add banner |

--- a/lang/en/emails/subscriptions/paypal-expiring.php
+++ b/lang/en/emails/subscriptions/paypal-expiring.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'title'   => 'Your Kanka subscription expires soon',
+    'dear'    => 'Dear :name',
+    'intro'   => 'Your Kanka PayPal subscription expires on **:date**. After that date your account will revert to the free tier.',
+    'loss'    => [
+        'title'   => 'Here is what you will lose:',
+        'campaign' => 'Premium campaign **:campaign**|Premium campaigns **:campaign** and :count more',
+        'players'  => ':count player will lose access|:count players will lose access',
+        'plugins'  => ':count marketplace plugin|:count marketplace plugins',
+        'ads'      => 'Ad-free experience',
+        'discord'  => 'Your **:role** Discord role',
+    ],
+    'cta'     => 'Renew your subscription',
+    'closing' => 'Yours truly,',
+];

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -216,6 +216,7 @@ return [
             'stripe'                => 'Your billing information is processed and stored safely through :stripe.',
         ],
         'manage_subscription'   => 'Manage subscription',
+        'paypal_expiring'       => 'Your PayPal subscription expires on :date. Renew now to avoid losing access.',
         'payment_method'        => [
             'actions'       => [
                 'add'               => 'Add',

--- a/lang/en/subscriptions/paypal-renew.php
+++ b/lang/en/subscriptions/paypal-renew.php
@@ -1,5 +1,9 @@
 <?php
 
 return [
-    'intro' => 'Your subscription expires on :date. Renewing will extend your access for one full year from that date.',
+    'intro' => 'Your subscription expires on :date. Renewing before then will extend your access for one full year from that date, and allow you to continue enjoying your perks without being interrupted.',
+    'success' => 'Your subscription has been renewed successfully until :date.',
+    'errors' => [
+        'permission' => 'Your subscription isn\'t set to expire in the next 14 days.',
+    ],
 ];

--- a/lang/en/subscriptions/paypal-renew.php
+++ b/lang/en/subscriptions/paypal-renew.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'intro' => 'Your subscription expires on :date. Renewing will extend your access for one full year from that date.',
+];

--- a/lang/en/subscriptions/renew.php
+++ b/lang/en/subscriptions/renew.php
@@ -5,5 +5,6 @@ return [
         'renew' => 'Renew subscription',
     ],
     'helper'    => 'However, you can choose to renew your subscription to enjoy the benefits without interruptions.',
+    'success'   => 'Your subscription has been renewed for one year.',
     'title'     => 'Subscription renewal',
 ];

--- a/resources/views/emails/subscriptions/cancelled/user-md.blade.php
+++ b/resources/views/emails/subscriptions/cancelled/user-md.blade.php
@@ -11,5 +11,5 @@ This email serves as confirmation that you have cancelled the renewal of your **
 
 Thank you for being part of our community!
 
-_Jay & Jon_
+__Jay & Jon__
 </x-mail::message>

--- a/resources/views/emails/subscriptions/charge-failed/user-md.blade.php
+++ b/resources/views/emails/subscriptions/charge-failed/user-md.blade.php
@@ -10,6 +10,6 @@ In the meantime, please verify your card details in your [billing information](h
 
 {{ __('emails/subscriptions/upcoming.closing') }}
 
-_Jay & Jon_
+__Jay & Jon__
 
 </x-mail::message>

--- a/resources/views/emails/subscriptions/expiring/user-md.blade.php
+++ b/resources/views/emails/subscriptions/expiring/user-md.blade.php
@@ -13,6 +13,6 @@
 
 {{ __('emails/subscriptions/upcoming.closing') }}
 
-_Jay & Jon_
+__Jay & Jon__
 
 </x-mail::message>

--- a/resources/views/emails/subscriptions/new/elemental.blade.php
+++ b/resources/views/emails/subscriptions/new/elemental.blade.php
@@ -14,6 +14,6 @@ Part of being an Elemental means that you get more say in how we shape community
 
 Good to have you among us {{ $user->name }},
 
-_Jay & Jon_
+__Jay & Jon__
 
 </x-mail::message>

--- a/resources/views/emails/subscriptions/new/owlbear.blade.php
+++ b/resources/views/emails/subscriptions/new/owlbear.blade.php
@@ -13,7 +13,7 @@ Unlock premium features
 
 Good to have you among us {{ $user->name }},
 
-_Jay & Jon_
+__Jay & Jon__
 
 </x-mail::message>
 

--- a/resources/views/emails/subscriptions/new/wyvern.blade.php
+++ b/resources/views/emails/subscriptions/new/wyvern.blade.php
@@ -12,6 +12,6 @@ Unlock premium features
 
 Good to have you among us {{ $user->name }},
 
-_Jay & Jon_
+__Jay & Jon__
 
 </x-mail::message>

--- a/resources/views/emails/subscriptions/paypal-expiring/user.blade.php
+++ b/resources/views/emails/subscriptions/paypal-expiring/user.blade.php
@@ -26,6 +26,6 @@
 
 {{ __('emails/subscriptions/paypal-expiring.closing') }}
 
-__Jay & Jon_
+__Jay & Jon__
 
 </x-mail::message>

--- a/resources/views/emails/subscriptions/paypal-expiring/user.blade.php
+++ b/resources/views/emails/subscriptions/paypal-expiring/user.blade.php
@@ -1,0 +1,31 @@
+<x-mail::message>
+
+{{ __('emails/subscriptions/paypal-expiring.dear', ['name' => $user->name]) }},
+
+{{ __('emails/subscriptions/paypal-expiring.intro', ['date' => $expiryDate]) }}
+
+{{ __('emails/subscriptions/paypal-expiring.loss.title') }}
+
+@if ($premiumCampaignName)
+- {{ trans_choice('emails/subscriptions/paypal-expiring.loss.campaign', $premiumCampaignCount - 1, ['campaign' => $premiumCampaignName, 'count' => $premiumCampaignCount - 1]) }}
+@if ($players > 0)
+  - {{ trans_choice('emails/subscriptions/paypal-expiring.loss.players', $players, ['count' => $players]) }}
+@endif
+@if ($plugins > 0)
+  - {{ trans_choice('emails/subscriptions/paypal-expiring.loss.plugins', $plugins, ['count' => $plugins]) }}
+@endif
+@endif
+- {{ __('emails/subscriptions/paypal-expiring.loss.ads') }}
+@if ($discord)
+- {{ __('emails/subscriptions/paypal-expiring.loss.discord', ['role' => $user->pledge]) }}
+@endif
+
+<x-mail::button :url="$renewUrl">
+{{ __('emails/subscriptions/paypal-expiring.cta') }}
+</x-mail::button>
+
+{{ __('emails/subscriptions/paypal-expiring.closing') }}
+
+__Jay & Jon_
+
+</x-mail::message>

--- a/resources/views/settings/subscription/index.blade.php
+++ b/resources/views/settings/subscription/index.blade.php
@@ -118,7 +118,7 @@
                     <div class="flex flex-col gap-2">
                         @includeIf('settings.subscription.tiers.benefits._' . $tier->code)
                     </div>
-                    @if (!$tier->isFree() && $tier->isCurrent($user) && $user->subscribed('kanka') && !$hasManual)
+                    @if (!$tier->isFree() && $tier->isCurrent($user) && $user->subscribed('kanka') && !$hasManual && !$user->hasPayPal())
                         <div class="self-bottom">
                             @if ($user->subscription('kanka')?->onGracePeriod())
                                 <a class="btn2 btn-block btn-sm btn-primary " data-toggle="dialog" data-target="subscribe-confirm" data-url="{{ route('settings.subscription.change', [$tier]) }}">

--- a/resources/views/settings/subscription/index.blade.php
+++ b/resources/views/settings/subscription/index.blade.php
@@ -26,6 +26,21 @@
 
         @include('partials.errors')
 
+        @can('renewPaypalSubscription', $user)
+            <x-alert type="warning">
+                <p class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <span>
+                        {!! __('settings.subscription.paypal_expiring', [
+                            'date' => '<strong>' . $user->subscription('kanka')->ends_at->isoFormat('MMMM D, Y') . '</strong>',
+                        ]) !!}
+                    </span>
+                    <a href="{{ route('paypal.renew') }}" class="btn2 btn-warning btn-sm whitespace-nowrap">
+                        {{ __('subscriptions/renew.actions.renew') }}
+                    </a>
+                </p>
+            </x-alert>
+        @endcan
+
         @include('settings.subscription._recap')
 
         <h2 class="text-xl m-0">

--- a/resources/views/settings/subscription/paypal-renew.blade.php
+++ b/resources/views/settings/subscription/paypal-renew.blade.php
@@ -26,15 +26,37 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         @foreach ($tiers as $tier)
             <article class="rounded-2xl bg-box flex flex-col gap-4 p-4 relative shadow-xs hover:shadow-md @if ($tier->isCurrent($user)) border-primary border @endif">
-                <div class="flex gap-2 items-center">
-                    <img src="{{ $tier->image() }}" alt="{{ $tier->name }}" class="w-10 h-10" />
-                    <h2 class="text-xl m-0">{{ $tier->name }}</h2>
-                    @if ($tier->isCurrent($user))
-                        <span class="badge badge-primary badge-sm">{{ __('tiers.current') }}</span>
-                    @endif
-                </div>
+                <div class="flex gap-2 flex-col ">
+                    <div class="flex justify-between gap-2">
+                        <img class="w-16 h-16 " src="{{ $tier->image() }}" alt="{{ $tier->name }}"/>
+                    </div>
+                    <div class="grow flex flex-col gap-2 w-full">
+                        <div class="text-lg">
+                            {{ $tier->name }}
+                        </div>
+                        @if ($tier->isFree())
+                            <div class="price text-neutral-content">
+                                {{ __('front.features.patreon.free') }}
+                            </div>
+                        @else
+                            <div class="price price-yearly flex gap-2 w-full items-end">
+                                <div class="text-2xl">
+                                    {{ $user->currencySymbol() }}
+                                    {{ number_format($tier->price($user->currency(), \App\Enums\PricingPeriod::Yearly), 2) }}
+                                </div>
+                                <span class="text-sm text-neutral-content ">{{ __('tiers.periods.billed_yearly') }}</span>
+                            </div>
+                        @endif
 
-                @include('settings.subscription.tiers.benefits._' . strtolower($tier->name))
+                        @if ($tier->code === 'owlbear')
+                            <p class="">{{ __('tiers.target.owlbear') }}</p>
+                        @elseif ($tier->isWyvern())
+                            <p class="">{{ __('tiers.target.wyvern') }}</p>
+                        @elseif ($tier->code === 'elemental')
+                            <p class="">{{ __('tiers.target.elemental') }}</p>
+                        @endif
+                    </div>
+                </div>
 
                 @php
                     $isDowngrade = match($user->pledge) {
@@ -45,14 +67,20 @@
                 @endphp
 
                 @if (!$isDowngrade)
-                    <x-form :action="['paypal.renew-process', 'tier' => $tier]" class="mt-auto">
-                        <x-buttons.confirm type="primary" class="btn-block">
-                            {{ $tier->isCurrent($user)
-                                ? __('subscriptions/renew.actions.renew')
-                                : __('tiers.actions.subscribe.upgrade', ['tier' => $tier->name]) }}
-                        </x-buttons.confirm>
+                    <x-form :action="['paypal.renew-process', 'tier' => $tier]" class="w-full" direct>
+                        <button type="submit" class="btn2 btn-primary btn-block">
+                                {{ $tier->isCurrent($user)
+                                    ? __('subscriptions/renew.actions.renew')
+                                    : __('tiers.actions.subscribe.upgrade', ['tier' => $tier->name]) }}
+                        </button>
                     </x-form>
                 @endif
+
+                <div class="flex flex-col gap-2">
+                    @include('settings.subscription.tiers.benefits._' . strtolower($tier->name))
+                </div>
+
+
             </article>
         @endforeach
     </div>

--- a/resources/views/settings/subscription/paypal-renew.blade.php
+++ b/resources/views/settings/subscription/paypal-renew.blade.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @var \App\Models\User $user
+ * @var \Illuminate\Database\Eloquent\Collection|\App\Models\Tier[] $tiers
+ */
+?>
+@extends('layouts.app', [
+    'title' => __('subscriptions/renew.title'),
+    'breadcrumbs' => false,
+    'sidebar' => 'settings',
+    'centered' => true,
+])
+
+@section('content')
+<x-grid type="1/1">
+    <h1 class="text-2xl">{{ __('subscriptions/renew.title') }}</h1>
+
+    <x-helper>
+        <p>
+            {!! __('subscriptions/paypal-renew.intro', [
+                'date' => '<strong>' . $user->subscription('kanka')->ends_at->isoFormat('MMMM D, Y') . '</strong>',
+            ]) !!}
+        </p>
+    </x-helper>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        @foreach ($tiers as $tier)
+            <article class="rounded-2xl bg-box flex flex-col gap-4 p-4 relative shadow-xs hover:shadow-md @if ($tier->isCurrent($user)) border-primary border @endif">
+                <div class="flex gap-2 items-center">
+                    <img src="{{ $tier->image() }}" alt="{{ $tier->name }}" class="w-10 h-10" />
+                    <h2 class="text-xl m-0">{{ $tier->name }}</h2>
+                    @if ($tier->isCurrent($user))
+                        <span class="badge badge-primary badge-sm">{{ __('tiers.current') }}</span>
+                    @endif
+                </div>
+
+                @include('settings.subscription.tiers.benefits._' . strtolower($tier->name))
+
+                @php
+                    $isDowngrade = match($user->pledge) {
+                        'Elemental' => in_array($tier->name, ['Owlbear', 'Wyvern']),
+                        'Wyvern'    => $tier->name === 'Owlbear',
+                        default     => false,
+                    };
+                @endphp
+
+                @if (!$isDowngrade)
+                    <x-form :action="['paypal.renew-process', 'tier' => $tier]" class="mt-auto">
+                        <x-buttons.confirm type="primary" class="btn-block">
+                            {{ $tier->isCurrent($user)
+                                ? __('subscriptions/renew.actions.renew')
+                                : __('tiers.actions.subscribe.upgrade', ['tier' => $tier->name]) }}
+                        </x-buttons.confirm>
+                    </x-form>
+                @endif
+            </article>
+        @endforeach
+    </div>
+</x-grid>
+@endsection

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -32,6 +32,7 @@ use App\Http\Controllers\Settings\Subscription\FinishController;
 use App\Http\Controllers\Settings\Subscription\FreeTrialController;
 use App\Http\Controllers\Settings\SubscriptionController;
 use App\Http\Controllers\Settings\TutorialController;
+use App\Http\Controllers\Subscription\PayPal\RenewalController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [ProfileController::class, 'index'])->name('settings');
@@ -176,6 +177,21 @@ Route::get('paypal/success-transaction', [PayPalController::class, 'successTrans
     ->name('paypal.transaction-success');
 Route::get('paypal/cancel-transaction', [PayPalController::class, 'cancelTransaction'])
     ->name('paypal.cancel-transaction');
+
+/*
+--------------------------------------------------------------------------
+PayPal Renewal
+--------------------------------------------------------------------------
+*/
+
+Route::get('subscription/paypal/renew', [RenewalController::class, 'index'])
+    ->name('paypal.renew');
+Route::post('subscription/paypal/renew/{tier}', [RenewalController::class, 'process'])
+    ->name('paypal.renew-process');
+Route::get('subscription/paypal/renew/success', [RenewalController::class, 'success'])
+    ->name('paypal.renew-success');
+Route::get('subscription/paypal/renew/cancel', [RenewalController::class, 'cancel'])
+    ->name('paypal.renew-cancel');
 
 /*
 --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a daily Artisan command (`subscriptions:paypal-expiring`) that finds PayPal subscribers expiring in 14 days and dispatches a reminder email with a \"what you'll lose\" breakdown (campaigns, players, plugins, Discord role, ad-free)
- Adds a dedicated PayPal renewal flow (`/subscription/paypal/renew`) that extends `ends_at = old_ends_at + 1 year` with optional tier upgrade (no proration)
- Adds a warning banner on the subscription settings page during the 2-week window, gated by `UserPolicy::renewPaypalSubscription`

## Test Plan

- [x] As a PayPal subscriber expiring in 14 days, verify the `subscriptions:paypal-expiring` command dispatches an email
- [x] Verify the email contains the correct expiry date, loss details, and renewal CTA link
- [x] Visit `/subscription/paypal/renew` as a PayPal subscriber within 14 days of expiry — confirm tier picker loads with current tier highlighted
- [x] Complete a PayPal renewal and verify `ends_at` extends from the old expiry date (not from today)
- [x] Verify `stripe_price` after renewal is `paypal_Owlbear` / `paypal_Wyvern` format (TitleCase)
- [x] Verify upgrading tier during renewal updates `user->pledge` correctly
- [x] Visit subscription settings as a PayPal subscriber within 14 days — confirm warning banner appears
- [x] Visit subscription settings outside the 14-day window — confirm banner is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)