### PR TITLE
feat: connected devices & per-device OTP (30-day memory)

### DIFF
--- a/app/Http/Controllers/Account/PasswordController.php
+++ b/app/Http/Controllers/Account/PasswordController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Account;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreSettingsAccount;
 use App\Jobs\Users\NewPassword;
+use App\Services\Auth\DeviceService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 
@@ -33,6 +34,7 @@ class PasswordController extends Controller
         NewPassword::dispatch(auth()->user());
 
         Auth::logoutOtherDevices($request->get('password_new'));
+        app(DeviceService::class)->revokeOthers(auth()->user());
 
         return redirect()
             ->route('settings.account')

--- a/app/Http/Controllers/Account/PasswordController.php
+++ b/app/Http/Controllers/Account/PasswordController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreSettingsAccount;
 use App\Jobs\Users\NewPassword;
 use App\Services\Auth\DeviceService;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 
 class PasswordController extends Controller
@@ -33,7 +32,6 @@ class PasswordController extends Controller
         auth()->user()->update($data);
         NewPassword::dispatch(auth()->user());
 
-        Auth::logoutOtherDevices($request->get('password_new'));
         app(DeviceService::class)->revokeOthers(auth()->user());
 
         return redirect()

--- a/app/Http/Controllers/Account/SocialController.php
+++ b/app/Http/Controllers/Account/SocialController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Account;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreSettingsAccount;
 use App\Services\Auth\DeviceService;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 
 class SocialController extends Controller
@@ -43,7 +42,6 @@ class SocialController extends Controller
         $data['password'] = Hash::make($request->post('password_new'));
 
         auth()->user()->update($data);
-        Auth::logoutOtherDevices($request->get('password_new'));
         app(DeviceService::class)->revokeOthers(auth()->user());
 
         return redirect()

--- a/app/Http/Controllers/Account/SocialController.php
+++ b/app/Http/Controllers/Account/SocialController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Account;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreSettingsAccount;
+use App\Services\Auth\DeviceService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 
@@ -43,6 +44,7 @@ class SocialController extends Controller
 
         auth()->user()->update($data);
         Auth::logoutOtherDevices($request->get('password_new'));
+        app(DeviceService::class)->revokeOthers(auth()->user());
 
         return redirect()
             ->route('settings.account')

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Models\UserDevice;
+use App\Services\Auth\DeviceService;
+use App\Services\Auth\UserAgentParser;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class SecurityController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'identity']);
+    }
+
+    public function index(Request $request, UserAgentParser $parser): View
+    {
+        $currentToken = $request->cookie(DeviceService::COOKIE_NAME);
+
+        $devices = auth()->user()
+            ->devices()
+            ->orderByDesc('last_active_at')
+            ->get()
+            ->map(fn (UserDevice $device) => [
+                'id' => $device->id,
+                'name' => $parser->parse($device->user_agent),
+                'ip_address' => $device->ip_address,
+                'last_active_at' => $device->last_active_at,
+                'is_current' => $device->token === $currentToken,
+            ]);
+
+        return view('settings.security', compact('devices'));
+    }
+
+    public function revoke(Request $request, UserDevice $device, DeviceService $deviceService): RedirectResponse
+    {
+        abort_if($device->user_id !== auth()->id(), 403);
+
+        $deviceService->revoke($device);
+
+        return redirect()->route('settings.security')
+            ->with('success', __('settings/security.devices.revoked'));
+    }
+
+    public function revokeOthers(Request $request, DeviceService $deviceService): RedirectResponse
+    {
+        $deviceService->revokeOthers(auth()->user());
+
+        return redirect()->route('settings.security')
+            ->with('success', __('settings/security.devices.revoked_others'));
+    }
+}

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -36,7 +36,7 @@ class SecurityController extends Controller
         return view('settings.security', compact('devices'));
     }
 
-    public function revoke(Request $request, UserDevice $device, DeviceService $deviceService): RedirectResponse
+    public function revoke(UserDevice $device, DeviceService $deviceService): RedirectResponse
     {
         abort_if($device->user_id !== auth()->id(), 403);
 
@@ -46,7 +46,7 @@ class SecurityController extends Controller
             ->with('success', __('settings/security.devices.revoked'));
     }
 
-    public function revokeOthers(Request $request, DeviceService $deviceService): RedirectResponse
+    public function revokeOthers(DeviceService $deviceService): RedirectResponse
     {
         $deviceService->revokeOthers(auth()->user());
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -58,6 +58,8 @@ class Kernel extends HttpKernel
             Middleware\LocalizeDatetime::class,
             Tracking::class,
             Middleware\CheckIfUserBanned::class,
+            Middleware\UpdateLastLoginAt::class,
+            Middleware\UpdateDeviceActivity::class,
             Middleware\OTP::class,
             ReplicationSwitcher::class,
         ],

--- a/app/Http/Middleware/UpdateDeviceActivity.php
+++ b/app/Http/Middleware/UpdateDeviceActivity.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\Auth\DeviceService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class UpdateDeviceActivity
+{
+    public function __construct(protected DeviceService $deviceService) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (auth()->check()) {
+            $token = $request->cookie(DeviceService::COOKIE_NAME);
+
+            if ($token) {
+                $device = $this->deviceService->findForUser(auth()->user());
+
+                if ($device === null) {
+                    auth()->logout();
+                    $request->session()->invalidate();
+                    $request->session()->regenerateToken();
+
+                    return redirect()->route('login');
+                }
+
+                $this->deviceService->touchActivity($device);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/UpdateLastLoginAt.php
+++ b/app/Http/Middleware/UpdateLastLoginAt.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Carbon\Carbon;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class UpdateLastLoginAt
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (auth()->check()) {
+            $user = auth()->user();
+            $today = Carbon::today();
+
+            if (! $user->last_login_at || $user->last_login_at->lt($today)) {
+                $user->updateQuietly(['last_login_at' => $today]);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Listeners/UserEventSubscriber.php
+++ b/app/Listeners/UserEventSubscriber.php
@@ -5,6 +5,7 @@ namespace App\Listeners;
 use App\Enums\UserAction;
 use App\Jobs\Emails\MailSettingsChangeJob;
 use App\Models\User;
+use App\Services\Auth\DeviceService;
 use App\Services\Auth\LoginService;
 use App\Services\Auth\SessionService;
 use Illuminate\Auth\Events\Login;
@@ -21,6 +22,7 @@ class UserEventSubscriber
     public function __construct(
         protected LoginService $loginService,
         protected SessionService $sessionService,
+        protected DeviceService $deviceService,
     ) {}
 
     /**
@@ -30,7 +32,7 @@ class UserEventSubscriber
     {
         /** @var User $user */
         $user = $event->user;
-        // Log the user's login
+
         if (! $user) {
             Log::error('Missing user in login event');
 
@@ -44,12 +46,12 @@ class UserEventSubscriber
             ->clearInactivityFlag()
             ->loadFlags();
 
-        // Update mailerlite for the login stuff
+        $this->deviceService->findOrCreate($user);
+
         if (! session()->has('first_login') && $user->hasNewsletter()) {
             MailSettingsChangeJob::dispatch($user);
         }
 
-        // Process invite token or first login
         $inviteResult = $this->sessionService->user($user)->handleInviteToken();
         if ($inviteResult !== null) {
             return $inviteResult;
@@ -66,9 +68,8 @@ class UserEventSubscriber
     /**
      * Handle user logout events.
      */
-    public function handleUserLogout(Logout $event)
+    public function handleUserLogout(Logout $event): void
     {
-        // Log the activity
         if (! $event->user) {
             return;
         }
@@ -77,9 +78,8 @@ class UserEventSubscriber
         }
     }
 
-    public function handleUserRegistered(Registered $event)
+    public function handleUserRegistered(Registered $event): void
     {
-        // If the user has an invite-token, we don't want to do anything else
         if (session()->has('invite_token')) {
             return;
         }

--- a/app/Listeners/UserEventSubscriber.php
+++ b/app/Listeners/UserEventSubscriber.php
@@ -46,7 +46,11 @@ class UserEventSubscriber
             ->clearInactivityFlag()
             ->loadFlags();
 
-        $this->deviceService->findOrCreate($user);
+        try {
+            $this->deviceService->findOrCreate($user);
+        } catch (\Exception $e) {
+            Log::error('Failed to create device record on login', ['user_id' => $user->id, 'error' => $e->getMessage()]);
+        }
 
         if (! session()->has('first_login') && $user->hasNewsletter()) {
             MailSettingsChangeJob::dispatch($user);

--- a/app/Livewire/Users/Otp.php
+++ b/app/Livewire/Users/Otp.php
@@ -76,6 +76,7 @@ class Otp extends Component
             // Update disabling OTP
             $user->passwordSecurity->google2fa_enable = 0;
             $user->passwordSecurity->save();
+            $user->devices()->update(['two_factor_verified_at' => null]);
             session()->flash('disable-success', __('settings.account.2fa.success_disable'));
         } else {
             $this->clickedBefore = true;

--- a/app/Models/OTPAuthentication.php
+++ b/app/Models/OTPAuthentication.php
@@ -31,7 +31,7 @@ class OTPAuthentication extends Authenticator
     {
         try {
             $secret = $this->getUser()->passwordSecurity->{$this->config('otp_secret_column')};
-        } catch (Exception $e) {
+        } catch (Exception) {
             $secret = $this->getUser()->passwordSecurity;
         }
 

--- a/app/Models/OTPAuthentication.php
+++ b/app/Models/OTPAuthentication.php
@@ -2,38 +2,57 @@
 
 namespace App\Models;
 
+use App\Services\Auth\DeviceService;
 use Exception;
 use PragmaRX\Google2FALaravel\Support\Authenticator;
 
 class OTPAuthentication extends Authenticator
 {
-    // If User does not have Google2FA Setup yet
-    protected function canPassWithoutCheckingOTP()
+    protected function canPassWithoutCheckingOTP(): bool
     {
         if (! isset($this->getUser()->passwordSecurity)) {
             return true;
         }
 
-        return ! $this->getUser()->passwordSecurity->google2fa_enable || ! $this->isEnabled() || $this->noUserIsAuthenticated() || $this->twoFactorAuthStillValid();
+        return ! $this->getUser()->passwordSecurity->google2fa_enable
+            || ! $this->isEnabled()
+            || $this->noUserIsAuthenticated()
+            || $this->twoFactorAuthStillValid()
+            || $this->deviceIsVerified();
     }
 
-    protected function getGoogle2FaSecretkey()
+    public function login(): void
     {
-        // Get User secret column
+        parent::login();
+        $this->markDeviceVerified();
+    }
+
+    protected function getGoogle2FaSecretkey(): mixed
+    {
         try {
             $secret = $this->getUser()->passwordSecurity->{$this->config('otp_secret_column')};
         } catch (Exception $e) {
-            // If User has not set up Google2FA
             $secret = $this->getUser()->passwordSecurity;
         }
 
-        // If User is not Authenticated through 2FA
         if (empty($secret)) {
-            // return Action
             return redirect()->action('PasswordSecurityController@generate2faSecretCode');
         }
 
-        // If user has Google2FA setup and is Authenticated
         return $secret;
+    }
+
+    private function deviceIsVerified(): bool
+    {
+        $device = app(DeviceService::class)->findForUser($this->getUser());
+
+        return $device !== null && $device->isTwoFactorVerified();
+    }
+
+    private function markDeviceVerified(): void
+    {
+        $device = app(DeviceService::class)->findForUser($this->getUser());
+
+        $device?->update(['two_factor_verified_at' => now()]);
     }
 }

--- a/app/Models/Relations/UserRelations.php
+++ b/app/Models/Relations/UserRelations.php
@@ -20,6 +20,7 @@ use App\Models\Role;
 use App\Models\SubscriptionCancellation;
 use App\Models\User;
 use App\Models\UserApp;
+use App\Models\UserDevice;
 use App\Models\UserFlag;
 use App\Models\UserLog;
 use App\Models\Users\Tutorial;
@@ -49,6 +50,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property PasswordSecurity|null $passwordSecurity
  * @property Collection|UserFlag[] $flags
  * @property Collection|Tutorial[] $tutorials
+ * @property Collection|UserDevice[] $devices
  */
 trait UserRelations
 {
@@ -268,5 +270,13 @@ trait UserRelations
     public function userValidation(): HasOne|UserValidation
     {
         return $this->hasOne(UserValidation::class, 'user_id', 'id');
+    }
+
+    /**
+     * @return HasMany<UserDevice, $this>
+     */
+    public function devices(): HasMany
+    {
+        return $this->hasMany(UserDevice::class);
     }
 }

--- a/app/Models/UserDevice.php
+++ b/app/Models/UserDevice.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property string $token
+ * @property ?string $session_id
+ * @property ?string $ip_address
+ * @property ?string $user_agent
+ * @property ?Carbon $two_factor_verified_at
+ * @property Carbon $last_active_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class UserDevice extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'token',
+        'session_id',
+        'ip_address',
+        'user_agent',
+        'two_factor_verified_at',
+        'last_active_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'two_factor_verified_at' => 'datetime',
+            'last_active_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function isTwoFactorVerified(): bool
+    {
+        return $this->two_factor_verified_at !== null
+            && $this->two_factor_verified_at->gte(now()->subDays(30));
+    }
+}

--- a/app/Models/UserDevice.php
+++ b/app/Models/UserDevice.php
@@ -2,9 +2,9 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasUser;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property int $id
@@ -20,7 +20,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class UserDevice extends Model
 {
-    protected $fillable = [
+    use HasUser;
+
+    public $fillable = [
         'user_id',
         'token',
         'session_id',
@@ -36,11 +38,6 @@ class UserDevice extends Model
             'two_factor_verified_at' => 'datetime',
             'last_active_at' => 'datetime',
         ];
-    }
-
-    public function user(): BelongsTo
-    {
-        return $this->belongsTo(User::class);
     }
 
     public function isTwoFactorVerified(): bool

--- a/app/Observers/UserLogObserver.php
+++ b/app/Observers/UserLogObserver.php
@@ -7,10 +7,11 @@ use App\Services\Auth\IpResolver;
 
 class UserLogObserver
 {
+    public function __construct(protected IpResolver $ipResolver) {}
+
     public function creating(UserLog $userLog): void
     {
-        $resolver = app(IpResolver::class);
-        $userLog->ip = $resolver->resolve();
+        $userLog->ip = $this->ipResolver->resolve();
         $userLog->country = mb_substr(request()->server('HTTP_CF_IPCOUNTRY') ?? '', 0, 6) ?: null;
     }
 }

--- a/app/Observers/UserLogObserver.php
+++ b/app/Observers/UserLogObserver.php
@@ -3,18 +3,14 @@
 namespace App\Observers;
 
 use App\Models\UserLog;
+use App\Services\Auth\IpResolver;
 
 class UserLogObserver
 {
-    public function creating(UserLog $userLog)
+    public function creating(UserLog $userLog): void
     {
-        $userLog->ip = request()->ip();
-        // In prod, requests come from our load balancers, so the real user ip is provided by Cloudflare.
-        $ip = request()->server('HTTP_CF_CONNECTING_IP');
-        if (! empty($ip)) {
-            $userLog->ip = $ip;
-            // While we're at it, track the user's country. All of this data is purged after 30 days.
-            $userLog->country = mb_substr(request()->server('HTTP_CF_IPCOUNTRY'), 0, 6);
-        }
+        $resolver = app(IpResolver::class);
+        $userLog->ip = $resolver->resolve();
+        $userLog->country = mb_substr(request()->server('HTTP_CF_IPCOUNTRY') ?? '', 0, 6) ?: null;
     }
 }

--- a/app/Services/Auth/DeviceService.php
+++ b/app/Services/Auth/DeviceService.php
@@ -4,7 +4,6 @@ namespace App\Services\Auth;
 
 use App\Models\User;
 use App\Models\UserDevice;
-use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Session;
@@ -30,7 +29,7 @@ class DeviceService
         $token = $this->request->cookie(self::COOKIE_NAME);
 
         if ($token) {
-            $device = UserDevice::where('token', $token)
+            $device = UserDevice::query()->where('token', $token)
                 ->where('user_id', $user->id)
                 ->first();
 
@@ -80,7 +79,7 @@ class DeviceService
             return null;
         }
 
-        return UserDevice::where('token', $token)
+        return UserDevice::query()->where('token', $token)
             ->where('user_id', $user->id)
             ->first();
     }
@@ -90,7 +89,7 @@ class DeviceService
      */
     public function touchActivity(UserDevice $device): void
     {
-        if ($device->last_active_at->lt(Carbon::now()->subHour())) {
+        if ($device->last_active_at->lt(now()->subHour())) {
             $device->update([
                 'session_id' => Session::getId(),
                 'ip_address' => $this->ipResolver->resolve(),
@@ -120,7 +119,7 @@ class DeviceService
     {
         $currentToken = $this->request->cookie(self::COOKIE_NAME);
 
-        $others = UserDevice::where('user_id', $user->id)
+        $others = UserDevice::query()->where('user_id', $user->id)
             ->when($currentToken, fn ($q) => $q->where('token', '!=', $currentToken))
             ->get();
 

--- a/app/Services/Auth/DeviceService.php
+++ b/app/Services/Auth/DeviceService.php
@@ -40,6 +40,8 @@ class DeviceService
                     'last_active_at' => now(),
                 ]);
 
+                $this->queueCookie($token);
+
                 return $device;
             }
         }
@@ -54,6 +56,13 @@ class DeviceService
             'last_active_at' => now(),
         ]);
 
+        $this->queueCookie($token);
+
+        return $device;
+    }
+
+    private function queueCookie(string $token): void
+    {
         Cookie::queue(
             self::COOKIE_NAME,
             $token,
@@ -65,8 +74,6 @@ class DeviceService
             false,
             'lax'
         );
-
-        return $device;
     }
 
     /**

--- a/app/Services/Auth/DeviceService.php
+++ b/app/Services/Auth/DeviceService.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services\Auth;
+
+use App\Models\User;
+use App\Models\UserDevice;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
+
+class DeviceService
+{
+    public const COOKIE_NAME = 'kanka_device';
+
+    public const COOKIE_DAYS = 30;
+
+    public function __construct(
+        protected Request $request,
+        protected IpResolver $ipResolver,
+    ) {}
+
+    /**
+     * Find the current device from the cookie, or create a new one.
+     * Queues the device cookie on the response.
+     */
+    public function findOrCreate(User $user): UserDevice
+    {
+        $token = $this->request->cookie(self::COOKIE_NAME);
+
+        if ($token) {
+            $device = UserDevice::where('token', $token)
+                ->where('user_id', $user->id)
+                ->first();
+
+            if ($device) {
+                $device->update([
+                    'session_id' => Session::getId(),
+                    'ip_address' => $this->ipResolver->resolve(),
+                    'last_active_at' => now(),
+                ]);
+
+                return $device;
+            }
+        }
+
+        $token = Str::random(64);
+        $device = UserDevice::create([
+            'user_id' => $user->id,
+            'token' => $token,
+            'session_id' => Session::getId(),
+            'ip_address' => $this->ipResolver->resolve(),
+            'user_agent' => $this->request->userAgent(),
+            'last_active_at' => now(),
+        ]);
+
+        Cookie::queue(
+            self::COOKIE_NAME,
+            $token,
+            60 * 24 * self::COOKIE_DAYS,
+            '/',
+            null,
+            config('session.secure'),
+            true,
+            false,
+            'lax'
+        );
+
+        return $device;
+    }
+
+    /**
+     * Find the device matching the current request's cookie for a given user.
+     */
+    public function findForUser(User $user): ?UserDevice
+    {
+        $token = $this->request->cookie(self::COOKIE_NAME);
+        if (! $token) {
+            return null;
+        }
+
+        return UserDevice::where('token', $token)
+            ->where('user_id', $user->id)
+            ->first();
+    }
+
+    /**
+     * Update session_id and last_active_at, rate-limited to once per hour.
+     */
+    public function touchActivity(UserDevice $device): void
+    {
+        if ($device->last_active_at->lt(Carbon::now()->subHour())) {
+            $device->update([
+                'session_id' => Session::getId(),
+                'ip_address' => $this->ipResolver->resolve(),
+                'last_active_at' => now(),
+            ]);
+        } elseif ($device->session_id !== Session::getId()) {
+            $device->updateQuietly(['session_id' => Session::getId()]);
+        }
+    }
+
+    /**
+     * Revoke a device: delete the DB record and destroy its Redis session immediately.
+     */
+    public function revoke(UserDevice $device): void
+    {
+        if ($device->session_id) {
+            Session::getHandler()->destroy($device->session_id);
+        }
+
+        $device->delete();
+    }
+
+    /**
+     * Revoke all devices for a user except the one matching the current cookie.
+     */
+    public function revokeOthers(User $user): void
+    {
+        $currentToken = $this->request->cookie(self::COOKIE_NAME);
+
+        $others = UserDevice::where('user_id', $user->id)
+            ->when($currentToken, fn ($q) => $q->where('token', '!=', $currentToken))
+            ->get();
+
+        foreach ($others as $device) {
+            $this->revoke($device);
+        }
+    }
+}

--- a/app/Services/Auth/IpResolver.php
+++ b/app/Services/Auth/IpResolver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services\Auth;
+
+use Illuminate\Http\Request;
+
+class IpResolver
+{
+    public function __construct(protected Request $request) {}
+
+    public function resolve(): string
+    {
+        $cf = $this->request->server('HTTP_CF_CONNECTING_IP');
+
+        return ! empty($cf) ? $cf : ($this->request->ip() ?? '');
+    }
+}

--- a/app/Services/Auth/UserAgentParser.php
+++ b/app/Services/Auth/UserAgentParser.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services\Auth;
+
+class UserAgentParser
+{
+    public function parse(?string $userAgent): string
+    {
+        if (empty($userAgent)) {
+            return __('settings/security.devices.unknown');
+        }
+
+        $browser = $this->parseBrowser($userAgent);
+        $os = $this->parseOs($userAgent);
+
+        if ($os) {
+            return "{$browser} on {$os}";
+        }
+
+        return $browser;
+    }
+
+    private function parseBrowser(string $ua): string
+    {
+        if (str_contains($ua, 'Edg/') || str_contains($ua, 'Edge/')) {
+            return 'Edge';
+        }
+        if (str_contains($ua, 'OPR/') || str_contains($ua, 'Opera/')) {
+            return 'Opera';
+        }
+        if (str_contains($ua, 'Firefox/')) {
+            return 'Firefox';
+        }
+        if (str_contains($ua, 'Chrome/')) {
+            return 'Chrome';
+        }
+        if (str_contains($ua, 'Safari/') && str_contains($ua, 'Version/')) {
+            return 'Safari';
+        }
+
+        return __('settings/security.devices.unknown_browser');
+    }
+
+    private function parseOs(string $ua): ?string
+    {
+        if (str_contains($ua, 'iPhone') || str_contains($ua, 'iPad')) {
+            return 'iOS';
+        }
+        if (str_contains($ua, 'Android')) {
+            return 'Android';
+        }
+        if (str_contains($ua, 'Macintosh') || str_contains($ua, 'Mac OS X')) {
+            return 'macOS';
+        }
+        if (str_contains($ua, 'Windows')) {
+            return 'Windows';
+        }
+        if (str_contains($ua, 'Linux')) {
+            return 'Linux';
+        }
+
+        return null;
+    }
+}

--- a/app/Services/Entity/EntitySaveService.php
+++ b/app/Services/Entity/EntitySaveService.php
@@ -15,7 +15,7 @@ use Stevebauman\Purify\Facades\Purify;
 class EntitySaveService
 {
     use CampaignAware;
-    
+
     public function __construct(
         protected TagService $tagService,
         protected PermissionService $permissionService,

--- a/database/migrations/2026_05_22_162143_create_user_devices_table.php
+++ b/database/migrations/2026_05_22_162143_create_user_devices_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_devices', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id');
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->string('token', 64)->unique();
+            $table->string('session_id', 255)->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamp('two_factor_verified_at')->nullable();
+            $table->timestamp('last_active_at');
+            $table->timestamps();
+
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_devices');
+    }
+};

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -108,6 +108,7 @@ return [
         'personal_settings'     => 'Personal Settings',
         'premium'               => 'Premium campaigns',
         'profile'               => 'Public profile',
+        'security'              => 'Security',
         'settings'              => 'Settings',
         'subscription'          => 'Subscription',
         'subscription_status'   => 'Subscription Status',

--- a/lang/en/settings/security.php
+++ b/lang/en/settings/security.php
@@ -6,7 +6,6 @@ return [
     'devices' => [
         'title' => 'Active Sessions',
         'current' => 'This device',
-        'revoke' => 'Revoke',
         'revoke_others' => 'Log out all other devices',
         'revoked' => 'Device has been logged out.',
         'revoked_others' => 'All other devices have been logged out.',
@@ -14,6 +13,6 @@ return [
         'unknown_browser' => 'Unknown browser',
         'last_active' => 'Last active',
         'ip_address' => 'IP address',
-        'empty' => 'No other active sessions found.',
+        'empty' => 'No active sessions found.',
     ],
 ];

--- a/lang/en/settings/security.php
+++ b/lang/en/settings/security.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    'title' => 'Security',
+    'helper' => 'Manage where you are logged in. Revoking a device will log it out immediately.',
+    'devices' => [
+        'title' => 'Active Sessions',
+        'current' => 'This device',
+        'revoke' => 'Revoke',
+        'revoke_others' => 'Log out all other devices',
+        'revoked' => 'Device has been logged out.',
+        'revoked_others' => 'All other devices have been logged out.',
+        'unknown' => 'Unknown device',
+        'unknown_browser' => 'Unknown browser',
+        'last_active' => 'Last active',
+        'ip_address' => 'IP address',
+        'empty' => 'No other active sessions found.',
+    ],
+];

--- a/resources/views/components/sidebar/account.blade.php
+++ b/resources/views/components/sidebar/account.blade.php
@@ -24,6 +24,13 @@
                     :text="__('settings.menu.account')"
                 ></x-sidebar.element>
             </li>
+            <li class="px-2 {{ $active('security') }}">
+                <x-sidebar.element
+                    :url="route('settings.security')"
+                    icon="fa-regular fa-shield"
+                    :text="__('settings.menu.security')"
+                ></x-sidebar.element>
+            </li>
             <li class="px-2 {{ $active('appearance') }}">
                 <x-sidebar.element
                     :url="route('settings.appearance')"

--- a/resources/views/livewire/users/otp.blade.php
+++ b/resources/views/livewire/users/otp.blade.php
@@ -45,7 +45,7 @@
                         <div class="field field-name">
                             <label>{{__('settings.account.2fa.fields.otp')}}</label>
 
-                            <input type="password" wire:model="otp" name="otp" maxlength="12" class="input rounded text-dark  w-full p-2" />
+                            <input type="text" wire:model="otp" name="otp" maxlength="12" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code" class="input rounded text-dark  w-full p-2" />
                             <div>
                                 @error('otp') <span class="text-error-content">{{ $message }}</span> @enderror
                             </div>

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -56,7 +56,7 @@
             @if ($devices->filter(fn ($d) => !$d['is_current'])->isNotEmpty())
                 <div class="flex justify-end mt-4">
                     <x-form :action="route('settings.security.revoke-others')" method="DELETE">
-                        <x-buttons.confirm type="outline" size="sm">
+                        <x-buttons.confirm type="danger" outline size="sm">
                             {{ __('settings/security.devices.revoke_others') }}
                         </x-buttons.confirm>
                     </x-form>

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -1,0 +1,67 @@
+@extends('layouts.app', [
+    'title' => __('settings/security.title'),
+    'breadcrumbs' => false,
+    'sidebar' => 'settings',
+    'centered' => true,
+])
+
+@section('content')
+    <x-hero>
+        <x-slot name="title">{{ __('settings/security.title') }}</x-slot>
+        <x-slot name="subtitle">{{ __('settings/security.helper') }}</x-slot>
+    </x-hero>
+
+    <x-box>
+        <x-slot name="title">{{ __('settings/security.devices.title') }}</x-slot>
+
+        @if ($devices->isEmpty())
+            <p>{{ __('settings/security.devices.empty') }}</p>
+        @else
+            <div class="table-responsive">
+                <table class="table table-default table-borderless table-hover">
+                    <thead>
+                        <tr>
+                            <th>{{ __('crud.fields.name') }}</th>
+                            <th>{{ __('settings/security.devices.ip_address') }}</th>
+                            <th>{{ __('settings/security.devices.last_active') }}</th>
+                            <th class="text-right">{{ __('crud.actions.actions') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($devices as $device)
+                            <tr>
+                                <td class="align-middle">
+                                    {{ $device['name'] ?: __('settings/security.devices.unknown') }}
+                                    @if ($device['is_current'])
+                                        <span class="badge badge-success ms-2">{{ __('settings/security.devices.current') }}</span>
+                                    @endif
+                                </td>
+                                <td class="align-middle">
+                                    {{ $device['ip_address'] ?? '—' }}
+                                </td>
+                                <td class="align-middle">
+                                    {{ $device['last_active_at'] ? $device['last_active_at']->diffForHumans() : '—' }}
+                                </td>
+                                <td class="align-middle text-right">
+                                    @if (!$device['is_current'])
+                                        <x-buttons.confirm-delete :route="route('settings.security.revoke', $device['id'])" />
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            @if ($devices->filter(fn ($d) => !$d['is_current'])->isNotEmpty())
+                <div class="flex justify-end mt-4">
+                    <x-form :action="route('settings.security.revoke-others')" method="DELETE">
+                        <x-buttons.confirm type="outline" size="sm">
+                            {{ __('settings/security.devices.revoke_others') }}
+                        </x-buttons.confirm>
+                    </x-form>
+                </div>
+            @endif
+        @endif
+    </x-box>
+@endsection

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -55,7 +55,7 @@
 
             @if ($devices->filter(fn ($d) => !$d['is_current'])->isNotEmpty())
                 <div class="flex justify-end mt-4">
-                    <x-form :action="route('settings.security.revoke-others')" method="DELETE">
+                    <x-form action="settings.security.revoke-others" method="DELETE">
                         <x-buttons.confirm type="danger" outline size="sm">
                             {{ __('settings/security.devices.revoke_others') }}
                         </x-buttons.confirm>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\Settings\PremiumController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\ReferralController;
 use App\Http\Controllers\Settings\ReleaseController;
+use App\Http\Controllers\Settings\SecurityController;
 use App\Http\Controllers\Settings\Subscription\CancellationController;
 use App\Http\Controllers\Settings\Subscription\CancelledController;
 use App\Http\Controllers\Settings\Subscription\FinishController;
@@ -83,6 +84,10 @@ Route::delete('/client/revoke/{client}', [ClientController::class, 'revoke'])->n
 
 Route::get('/appearance', [AppearanceController::class, 'index'])->name('settings.appearance');
 Route::patch('/appearance', [AppearanceController::class, 'update'])->name('settings.appearance.update');
+
+Route::get('/security', [SecurityController::class, 'index'])->name('settings.security');
+Route::delete('/security/devices/{device}', [SecurityController::class, 'revoke'])->name('settings.security.revoke');
+Route::delete('/security/devices', [SecurityController::class, 'revokeOthers'])->name('settings.security.revoke-others');
 
 Route::get('/newsletter', [NewsletterController::class, 'index'])->name('settings.newsletter');
 Route::patch('/newsletter', [NewsletterController::class, 'update'])->name('settings.newsletter.save');


### PR DESCRIPTION
## Summary

- Adds `user_devices` table + `kanka_device` cookie (30-day, HTTP-only) to identify browsers across session restarts
- OTP (2FA) verification is now remembered per device for 30 days — `SESSION_LIFETIME` can be dropped from 43200 to 120 in production `.env`
- New **Security** settings page (`/settings/security`) lets users see all active sessions and revoke any device immediately (Redis session destroyed server-side on revoke)
- Clears device OTP state when 2FA is disabled, preventing bypass on re-enable

## Key changes

- `user_devices` migration + `UserDevice` model
- `IpResolver` (Cloudflare-aware) + `UserAgentParser` (no new deps, str_contains detection)
- `DeviceService` — find/create device on login, touch activity, revoke, revoke-others
- `UpdateDeviceActivity` middleware — rate-limited activity tracking; force-logout on revoked device mid-session
- `OTPAuthentication` — device-aware `canPassWithoutCheckingOTP` + `markDeviceVerified` on OTP success
- `UserEventSubscriber` — calls `DeviceService::findOrCreate` on login
- `Settings\SecurityController` + view + translations + sidebar entry

## Deployment note

Set `SESSION_LIFETIME=120` in production `.env` (was 43200 — the long lifetime was the workaround this feature replaces).

## Test plan

- [x] Log in — `user_devices` row created, `kanka_device` cookie set (30-day)
- [x] Log in again on same browser — existing row updated (not duplicated), cookie refreshed
- [x] Enable 2FA, verify OTP — `two_factor_verified_at` set; subsequent requests skip OTP prompt
- [x] Let session expire (or clear session cookie) — re-auth without OTP prompt (device still verified)
- [x] Visit `/settings/security` — active sessions table visible, current device has "This device" badge
- [x] Revoke a device from another browser — that browser is immediately logged out on next request
- [x] "Log out all other devices" — all non-current devices revoked
- [x] Disable 2FA — all devices' `two_factor_verified_at` cleared; re-enabling 2FA requires fresh OTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)