### PR TITLE
feat: replace cookieconsent popup with footer-integrated consent bar

### DIFF
--- a/lang/de/cookieconsent.php
+++ b/lang/de/cookieconsent.php
@@ -7,5 +7,6 @@ return [
     'link'      => 'Erfahre mehr',
     'message'   => 'Kanka verwendet Cookies, um sicherzustellen, dass du das beste Erlebnis auf unserer Website hast.',
     'policy'    => 'Cookie-Richtlinie',
-    'reject'    => 'Verfall',
+    'reject'      => 'Verfall',
+    'preferences' => 'Cookie-Einstellungen',
 ];

--- a/lang/en/cookieconsent.php
+++ b/lang/en/cookieconsent.php
@@ -7,5 +7,6 @@ return [
     'link'      => 'Learn more',
     'message'   => 'Kanka uses cookies to ensure you get the best experience on our website.',
     'policy'    => 'Cookie policy',
-    'reject'    => 'Decline',
+    'reject'      => 'Decline',
+    'preferences' => 'Cookie preferences',
 ];

--- a/lang/es/cookieconsent.php
+++ b/lang/es/cookieconsent.php
@@ -7,5 +7,6 @@ return [
     'link'      => 'Más información',
     'message'   => 'Kanka utiliza cookies para que tengas la mejor experiencia en nuestro sitio web.',
     'policy'    => 'Política de cookies',
-    'reject'    => 'Declinar',
+    'reject'      => 'Declinar',
+    'preferences' => 'Preferencias de cookies',
 ];

--- a/lang/fr/cookieconsent.php
+++ b/lang/fr/cookieconsent.php
@@ -7,5 +7,6 @@ return [
     'link'      => 'En savoir plus',
     'message'   => 'Kanka utilise des cookies pour garantir une expérience optimale du site web.',
     'policy'    => 'Politique en matière de cookies',
-    'reject'    => 'Rejeter',
+    'reject'      => 'Rejeter',
+    'preferences' => 'Préférences de cookies',
 ];

--- a/lang/it/cookieconsent.php
+++ b/lang/it/cookieconsent.php
@@ -7,5 +7,6 @@ return [
     'link'      => 'Ulteriori informazioni',
     'message'   => 'Kanka utilizza i cookie per garantire la migliore esperienza sul nostro sito web.',
     'policy'    => 'Informativa sui cookies',
-    'reject'    => 'Rifiuta',
+    'reject'      => 'Rifiuta',
+    'preferences' => 'Preferenze cookie',
 ];

--- a/lang/pl/cookieconsent.php
+++ b/lang/pl/cookieconsent.php
@@ -7,5 +7,6 @@ return [
     'link'      => 'Szczegóły',
     'message'   => 'Kanka wykorzystuje cookies by zagwarantować jak najlepsze doświadczanie użytkownika.',
     'policy'    => 'Polityka cookies',
-    'reject'    => 'Nie zezwalaj',
+    'reject'      => 'Nie zezwalaj',
+    'preferences' => 'Preferencje plików cookie',
 ];

--- a/lang/pt-BR/cookieconsent.php
+++ b/lang/pt-BR/cookieconsent.php
@@ -7,5 +7,6 @@ return [
     'link'      => 'Saiba mais',
     'message'   => 'Kanka usa cookies para garantir que você obtenha a melhor experiência em nosso site.',
     'policy'    => 'Política de cookies',
-    'reject'    => 'Recusar',
+    'reject'      => 'Recusar',
+    'preferences' => 'Preferências de cookies',
 ];

--- a/lang/sk/cookieconsent.php
+++ b/lang/sk/cookieconsent.php
@@ -7,5 +7,6 @@ return [
     'link'      => 'Dozvedieť sa viac',
     'message'   => 'Kanka používa cookies, aby ti umožnila čo najlepšie využívať našu webovú stránku.',
     'policy'    => 'Podmienky cookies',
-    'reject'    => 'Nesúhlasím',
+    'reject'      => 'Nesúhlasím',
+    'preferences' => 'Nastavenia cookies',
 ];

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
         "click-outside-vue3": "^4.0.1",
         "codemirror": "^6.0.2",
         "colord": "^2.9.3",
-        "cookieconsent": "3",
         "cytoscape": "^3.27.0",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-dblclick": "^0.3.1",

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -180,7 +180,7 @@
     "src": "node_modules/rpg-awesome/fonts/rpgawesome-webfont.woff"
   },
   "resources/css/app.css": {
-    "file": "assets/app-BTDfzSxc.css",
+    "file": "assets/app-BdkwTA0h.css",
     "src": "resources/css/app.css",
     "isEntry": true,
     "name": "app",
@@ -189,7 +189,7 @@
     ]
   },
   "resources/css/auth.css": {
-    "file": "assets/auth-CSCEOzAT.css",
+    "file": "assets/auth-B1Dv6cFM.css",
     "src": "resources/css/auth.css",
     "isEntry": true,
     "name": "auth",
@@ -216,7 +216,7 @@
     ]
   },
   "resources/css/front.css": {
-    "file": "assets/front-C49QfhWk.css",
+    "file": "assets/front-DI7tJiTW.css",
     "src": "resources/css/front.css",
     "isEntry": true,
     "name": "front",
@@ -423,7 +423,7 @@
     ]
   },
   "resources/js/cookieconsent.js": {
-    "file": "assets/cookieconsent-DM0O5r9k.js",
+    "file": "assets/cookieconsent-B5eqXZqG.js",
     "name": "cookieconsent",
     "src": "resources/js/cookieconsent.js",
     "isEntry": true

--- a/resources/js/cookieconsent.js
+++ b/resources/js/cookieconsent.js
@@ -1,102 +1,43 @@
-import 'cookieconsent/build/cookieconsent.min.js';
+const COOKIE_LAW_COUNTRIES = [
+    'AT', 'BE', 'BG', 'HR', 'CZ', 'CY', 'DK', 'EE', 'FI', 'FR',
+    'DE', 'EL', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL',
+    'PL', 'PT', 'SK', 'ES', 'SE', 'GB', 'UK', 'GR', 'EU',
+];
+
 const field = document.getElementById('cookieconsent');
-let setup, api;
 
-const initCookieConsent = () => {
-    if (!field) {
-        return;
-    }
-    setup = field.dataset.setup;
-
-    api = field.dataset.api;
-
-    //console.log('init cookie consent');
-    window.cookieconsent.initialise({
-        type: 'opt-in',
-        layout: 'basic',
-        content: JSON.parse(setup),
-        // location: {
-        //     timeout: 5000,
-        //     services: ['kanka'],
-        //     serviceDefinitions: {
-        //         kanka: function () {
-        //             return {
-        //                 // This service responds with JSON, so we simply need to parse it and return the country code
-        //                 url: api,
-        //                 headers: ['Accept: application/json'],
-        //                 callback: function (done, response) {
-        //                     try {
-        //                         var json = JSON.parse(response);
-        //                         return json.error
-        //                             ? toError(json)
-        //                             : {
-        //                                 code: json.country
-        //                             };
-        //                     } catch (err) {
-        //                         return toError({error: 'Invalid response (' + err + ')'});
-        //                     }
-        //                 }
-        //             };
-        //         },
-        //     },
-        // },
-        law: {
-            countryCode: field.dataset.country
-        },
-        palette: {
-            "popup": { "background": "#08083c", "text": "#ffffff" },
-            "button": { "background": "#007bff", "text": "#ffffff" },
-        },
-        onPopupOpen: function () {
-            //console.log('<em>onPopupOpen()</em> called');
-        },
-        onPopupClose: function () {
-            //console.log('<em>onPopupClose()</em> called');
-        },
-        onInitialise: function (status) {
-            //console.log('<em>onInitialise()</em> called with status <em>' + status + '</em>');
-            if (status === 'allow') {
-                initTracking();
-            }
-        },
-        onStatusChange: function (status) {
-            //console.log('<em>onStatusChange()</em> called with status <em>' + status + '</em>');
-            if (status === 'allow') {
-                initTracking();
-            }
-        },
-        onRevokeChoice: function () {
-            //console.log('<em>onRevokeChoice()</em> called');
-        },
-        onNoCookieLaw: function () {
-            initTracking();
-        }
-    });
+const getCookie = (name) => {
+    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    return match ? match[2] : null;
 };
 
-const toError = (obj) => {
-    return new Error('Error [' + (obj.code || 'UNKNOWN') + ']: ' + obj.error);
+const setCookie = (name, value, days) => {
+    const date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    document.cookie = name + '=' + value + '; expires=' + date.toUTCString() + '; path=/';
 };
 
 const initTracking = () => {
-    // console.log('initTracking', field.dataset);
+    if (!field) {
+        return;
+    }
     if (field.dataset.gtag) {
-        // console.log('add gtag');
         allConsentGranted();
     }
     if (field.dataset.gtm) {
-        // console.log('add gtm');
-        initGTM(window,document,'script','dataLayer', field.dataset.gtm);
+        initGTM(window, document, 'script', 'dataLayer', field.dataset.gtm);
     }
 };
 
-const initGTM = (w,d,s,l,i) => {
-    w[l]=w[l]||[];
-    w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
-    var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-    j.async=true;
-    j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
-    f.parentNode.insertBefore(j,f);
+const initGTM = (w, d, s, l, i) => {
+    w[l] = w[l] || [];
+    w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+    const f = d.getElementsByTagName(s)[0];
+    const j = d.createElement(s);
+    const dl = l !== 'dataLayer' ? '&l=' + l : '';
+    j.async = true;
+    j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+    f.parentNode.insertBefore(j, f);
 };
 
 const allConsentGranted = () => {
@@ -104,8 +45,46 @@ const allConsentGranted = () => {
         'ad_user_data': 'granted',
         'ad_personalization': 'granted',
         'ad_storage': 'granted',
-        'analytics_storage': 'granted'
+        'analytics_storage': 'granted',
     });
 };
 
-initCookieConsent();
+const initOnLoad = () => {
+    if (!field) {
+        return;
+    }
+    const country = field.dataset.country;
+    const status = getCookie('cookieconsent_status');
+
+    if (!COOKIE_LAW_COUNTRIES.includes(country)) {
+        initTracking();
+        return;
+    }
+
+    if (status === 'allow') {
+        initTracking();
+    }
+};
+
+window.footerCookieConsent = () => ({
+    showConsent: false,
+    init() {
+        if (!field) {
+            return;
+        }
+        const country = field.dataset.country;
+        const status = getCookie('cookieconsent_status');
+        this.showConsent = COOKIE_LAW_COUNTRIES.includes(country) && !status;
+    },
+    accept() {
+        setCookie('cookieconsent_status', 'allow', 365);
+        this.showConsent = false;
+        initTracking();
+    },
+    reject() {
+        setCookie('cookieconsent_status', 'deny', 365);
+        this.showConsent = false;
+    },
+});
+
+initOnLoad();

--- a/resources/js/cookieconsent.js
+++ b/resources/js/cookieconsent.js
@@ -7,14 +7,14 @@ const COOKIE_LAW_COUNTRIES = [
 const field = document.getElementById('cookieconsent');
 
 const getCookie = (name) => {
-    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    const match = document.cookie.match(new RegExp('(^| )' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]+)'));
     return match ? match[2] : null;
 };
 
 const setCookie = (name, value, days) => {
     const date = new Date();
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-    document.cookie = name + '=' + value + '; expires=' + date.toUTCString() + '; path=/';
+    document.cookie = name + '=' + value + '; expires=' + date.toUTCString() + '; path=/; SameSite=Lax';
 };
 
 const initTracking = () => {

--- a/resources/js/cookieconsent.js
+++ b/resources/js/cookieconsent.js
@@ -66,31 +66,48 @@ const initOnLoad = () => {
     }
 };
 
-document.addEventListener('alpine:init', () => {
-    Alpine.data('footerCookieConsent', () => ({
-        showConsent: false,
-        init() {
-            if (!field) {
-                return;
-            }
-            const country = field.dataset.country;
-            const status = getCookie('cookieconsent_status');
-            this.showConsent = COOKIE_LAW_COUNTRIES.includes(country) && !status;
-        },
-        accept() {
-            setCookie('cookieconsent_status', 'allow', 365);
-            this.showConsent = false;
-            initTracking();
-        },
-        reject() {
-            setCookie('cookieconsent_status', 'deny', 365);
-            this.showConsent = false;
-        },
-        reset() {
-            setCookie('cookieconsent_status', '', -1);
-            this.showConsent = true;
-        },
-    }));
-});
+const setupConsentBar = () => {
+    if (!field) {
+        return;
+    }
 
-initOnLoad();
+    const country = field.dataset.country;
+    const status = getCookie('cookieconsent_status');
+
+    if (!COOKIE_LAW_COUNTRIES.includes(country)) {
+        initTracking();
+        return;
+    }
+
+    if (status === 'allow') {
+        initTracking();
+        return;
+    }
+
+    const bar = document.querySelector('[data-cookie-consent-bar]');
+    if (!bar) {
+        return;
+    }
+
+    if (!status) {
+        bar.style.display = '';
+    }
+
+    bar.querySelector('[data-accept]')?.addEventListener('click', () => {
+        setCookie('cookieconsent_status', 'allow', 365);
+        bar.style.display = 'none';
+        initTracking();
+    });
+
+    bar.querySelector('[data-reject]')?.addEventListener('click', () => {
+        setCookie('cookieconsent_status', 'deny', 365);
+        bar.style.display = 'none';
+    });
+
+    window.addEventListener('show-cookie-consent', () => {
+        setCookie('cookieconsent_status', '', -1);
+        bar.style.display = '';
+    });
+};
+
+setupConsentBar();

--- a/resources/js/cookieconsent.js
+++ b/resources/js/cookieconsent.js
@@ -66,29 +66,31 @@ const initOnLoad = () => {
     }
 };
 
-window.footerCookieConsent = () => ({
-    showConsent: false,
-    init() {
-        if (!field) {
-            return;
-        }
-        const country = field.dataset.country;
-        const status = getCookie('cookieconsent_status');
-        this.showConsent = COOKIE_LAW_COUNTRIES.includes(country) && !status;
-    },
-    accept() {
-        setCookie('cookieconsent_status', 'allow', 365);
-        this.showConsent = false;
-        initTracking();
-    },
-    reject() {
-        setCookie('cookieconsent_status', 'deny', 365);
-        this.showConsent = false;
-    },
-    reset() {
-        setCookie('cookieconsent_status', '', -1);
-        this.showConsent = true;
-    },
+document.addEventListener('alpine:init', () => {
+    Alpine.data('footerCookieConsent', () => ({
+        showConsent: false,
+        init() {
+            if (!field) {
+                return;
+            }
+            const country = field.dataset.country;
+            const status = getCookie('cookieconsent_status');
+            this.showConsent = COOKIE_LAW_COUNTRIES.includes(country) && !status;
+        },
+        accept() {
+            setCookie('cookieconsent_status', 'allow', 365);
+            this.showConsent = false;
+            initTracking();
+        },
+        reject() {
+            setCookie('cookieconsent_status', 'deny', 365);
+            this.showConsent = false;
+        },
+        reset() {
+            setCookie('cookieconsent_status', '', -1);
+            this.showConsent = true;
+        },
+    }));
 });
 
 initOnLoad();

--- a/resources/js/cookieconsent.js
+++ b/resources/js/cookieconsent.js
@@ -85,6 +85,10 @@ window.footerCookieConsent = () => ({
         setCookie('cookieconsent_status', 'deny', 365);
         this.showConsent = false;
     },
+    reset() {
+        setCookie('cookieconsent_status', '', -1);
+        this.showConsent = true;
+    },
 });
 
 initOnLoad();

--- a/resources/js/cookieconsent.js
+++ b/resources/js/cookieconsent.js
@@ -1,7 +1,7 @@
 const COOKIE_LAW_COUNTRIES = [
     'AT', 'BE', 'BG', 'HR', 'CZ', 'CY', 'DK', 'EE', 'FI', 'FR',
-    'DE', 'EL', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL',
-    'PL', 'PT', 'SK', 'ES', 'SE', 'GB', 'UK', 'GR', 'EU',
+    'DE', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL',
+    'PL', 'PT', 'SK', 'ES', 'SE', 'GB', 'GR',
 ];
 
 const field = document.getElementById('cookieconsent');
@@ -14,7 +14,7 @@ const getCookie = (name) => {
 const setCookie = (name, value, days) => {
     const date = new Date();
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-    document.cookie = name + '=' + value + '; expires=' + date.toUTCString() + '; path=/; SameSite=Lax';
+    document.cookie = name + '=' + value + '; expires=' + date.toUTCString() + '; path=/; SameSite=Lax; Secure';
 };
 
 const initTracking = () => {

--- a/resources/views/front/footer.blade.php
+++ b/resources/views/front/footer.blade.php
@@ -1,7 +1,7 @@
 <footer class="bg-dark text-light py-12 px-6">
     <div class="mx-auto lg:max-w-7xl flex flex-col gap-10">
         @if(config('tracking.consent'))
-        <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak class="rounded-lg border border-white/10 bg-white/5 p-4">
+        <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak @show-cookie-consent.window="reset()" class="rounded-lg border border-white/10 bg-white/5 p-4">
             <div class="flex flex-col gap-3 text-sm sm:flex-row sm:items-center">
                 <p class="flex-1 text-white/70">
                     {{ __('cookieconsent.message') }}
@@ -74,6 +74,9 @@
                 <a href="{{ Domain::toFront('terms-and-conditions') }}">{{ __('footer.terms') }}</a>
                 <a href="{{ Domain::toFront('security') }}">{{ __('footer.security') }}</a>
                 <a href="{{ Domain::toFront('press-kit') }}">{{ __('footer.press-kit') }}</a>
+                @if(config('tracking.consent'))
+                <a href="#" x-data @click.prevent="$dispatch('show-cookie-consent')">{{ __('cookieconsent.preferences') }}</a>
+                @endif
             </div>
         </div>
 

--- a/resources/views/front/footer.blade.php
+++ b/resources/views/front/footer.blade.php
@@ -1,5 +1,19 @@
 <footer class="bg-dark text-light py-12 px-6">
     <div class="mx-auto lg:max-w-7xl flex flex-col gap-10">
+        @if(config('tracking.consent'))
+        <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak class="rounded-lg border border-white/10 bg-white/5 p-4">
+            <div class="flex flex-col gap-3 text-sm sm:flex-row sm:items-center">
+                <p class="flex-1 text-white/70">
+                    {{ __('cookieconsent.message') }}
+                    <a href="{{ Domain::toFront('privacy-policy') }}" target="_blank" class="text-blue-400 hover:underline">{{ __('cookieconsent.link') }}</a>
+                </p>
+                <div class="flex shrink-0 gap-2">
+                    <button @click="accept()" class="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700">{{ __('cookieconsent.allow') }}</button>
+                    <button @click="reject()" class="rounded border border-white/20 px-3 py-1 text-xs text-white/60 hover:border-white/40">{{ __('cookieconsent.reject') }}</button>
+                </div>
+            </div>
+        </div>
+        @endif
         <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-5">
             <div class="flex-col gap-8 hidden lg:flex col-span-2 ">
                 <div class="flex">

--- a/resources/views/front/footer.blade.php
+++ b/resources/views/front/footer.blade.php
@@ -1,15 +1,15 @@
 <footer class="bg-dark text-light py-12 px-6">
     <div class="mx-auto lg:max-w-7xl flex flex-col gap-10">
         @if(config('tracking.consent'))
-        <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak @show-cookie-consent.window="reset()" class="rounded-lg border border-white/10 bg-white/5 p-4">
+        <div data-cookie-consent-bar style="display: none;" class="rounded-lg border border-white/10 bg-white/5 p-4">
             <div class="flex flex-col gap-3 text-sm sm:flex-row sm:items-center">
                 <p class="flex-1 text-white/70">
                     {{ __('cookieconsent.message') }}
                     <a href="{{ Domain::toFront('privacy-policy') }}" target="_blank" class="text-blue-400 hover:underline">{{ __('cookieconsent.link') }}</a>
                 </p>
                 <div class="flex shrink-0 gap-2">
-                    <button @click="accept()" class="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700">{{ __('cookieconsent.allow') }}</button>
-                    <button @click="reject()" class="rounded border border-white/20 px-3 py-1 text-xs text-white/60 hover:border-white/40">{{ __('cookieconsent.reject') }}</button>
+                    <button data-accept class="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700">{{ __('cookieconsent.allow') }}</button>
+                    <button data-reject class="rounded border border-white/20 px-3 py-1 text-xs text-white/60 hover:border-white/40">{{ __('cookieconsent.reject') }}</button>
                 </div>
             </div>
         </div>

--- a/resources/views/front/footer.blade.php
+++ b/resources/views/front/footer.blade.php
@@ -75,7 +75,7 @@
                 <a href="{{ Domain::toFront('security') }}">{{ __('footer.security') }}</a>
                 <a href="{{ Domain::toFront('press-kit') }}">{{ __('footer.press-kit') }}</a>
                 @if(config('tracking.consent'))
-                <a href="#" x-data @click.prevent="$dispatch('show-cookie-consent')">{{ __('cookieconsent.preferences') }}</a>
+                <a href="#" onclick="window.dispatchEvent(new CustomEvent('show-cookie-consent')); return false;">{{ __('cookieconsent.preferences') }}</a>
                 @endif
             </div>
         </div>

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -1,6 +1,20 @@
 <footer id="footer" class="main-footer px-4 py-10 print:hidden">
     <div class="lg:max-w-7xl lg:mx-auto">
         <div class="flex flex-col gap-10">
+            @if(config('tracking.consent'))
+            <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak class="rounded-lg border border-base-300 bg-base-200/50 p-4">
+                <div class="flex flex-col gap-3 text-sm sm:flex-row sm:items-center">
+                    <p class="flex-1 text-neutral-content">
+                        {{ __('cookieconsent.message') }}
+                        <a href="{{ Domain::toFront('privacy-policy') }}" target="_blank" class="text-link">{{ __('cookieconsent.link') }}</a>
+                    </p>
+                    <div class="flex shrink-0 gap-2">
+                        <button @click="accept()" class="btn btn-xs btn-primary">{{ __('cookieconsent.allow') }}</button>
+                        <button @click="reject()" class="btn btn-xs btn-ghost">{{ __('cookieconsent.reject') }}</button>
+                    </div>
+                </div>
+            </div>
+            @endif
             <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-5">
                 <div class="flex-col gap-4 hidden lg:flex col-span-2 ">
                     <div class="flex">

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -85,7 +85,7 @@
                     <a href="{{ Domain::toFront('security') }}" class="text-link">{{ __('footer.security') }}</a>
                     <a href="{{ Domain::toFront('press-kit') }}" class="text-link">{{ __('footer.press-kit') }}</a>
                     @if(config('tracking.consent'))
-                    <a href="#" x-data @click.prevent="$dispatch('show-cookie-consent')" class="text-link">{{ __('cookieconsent.preferences') }}</a>
+                    <a href="#" onclick="window.dispatchEvent(new CustomEvent('show-cookie-consent')); return false;" class="text-link">{{ __('cookieconsent.preferences') }}</a>
                     @endif
                 </div>
             </div>

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -2,15 +2,15 @@
     <div class="lg:max-w-7xl lg:mx-auto">
         <div class="flex flex-col gap-10">
             @if(config('tracking.consent'))
-            <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak @show-cookie-consent.window="reset()" class="rounded-xl bg-base-100 p-4">
+            <div data-cookie-consent-bar style="display: none;" class="rounded-xl bg-base-100 p-4">
                 <div class="flex flex-col gap-3 text-sm sm:flex-row sm:items-center">
                     <p class="flex-1 text-neutral-content">
                         {{ __('cookieconsent.message') }}
                         <a href="{{ Domain::toFront('privacy-policy') }}" target="_blank" class="text-link">{{ __('cookieconsent.link') }}</a>
                     </p>
                     <div class="flex shrink-0 gap-2">
-                        <button @click="accept()" class="btn2 btn-xs btn-primary">{{ __('cookieconsent.allow') }}</button>
-                        <button @click="reject()" class="btn2 btn-xs btn-ghost">{{ __('cookieconsent.reject') }}</button>
+                        <button data-accept class="btn2 btn-xs btn-primary">{{ __('cookieconsent.allow') }}</button>
+                        <button data-reject class="btn2 btn-xs btn-ghost">{{ __('cookieconsent.reject') }}</button>
                     </div>
                 </div>
             </div>

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -2,7 +2,7 @@
     <div class="lg:max-w-7xl lg:mx-auto">
         <div class="flex flex-col gap-10">
             @if(config('tracking.consent'))
-            <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak class="rounded-xl bg-base-100 p-4">
+            <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak @show-cookie-consent.window="reset()" class="rounded-xl bg-base-100 p-4">
                 <div class="flex flex-col gap-3 text-sm sm:flex-row sm:items-center">
                     <p class="flex-1 text-neutral-content">
                         {{ __('cookieconsent.message') }}
@@ -84,6 +84,9 @@
                     <a href="{{ Domain::toFront('terms-and-conditions') }}" class="text-link">{{ __('footer.terms') }}</a>
                     <a href="{{ Domain::toFront('security') }}" class="text-link">{{ __('footer.security') }}</a>
                     <a href="{{ Domain::toFront('press-kit') }}" class="text-link">{{ __('footer.press-kit') }}</a>
+                    @if(config('tracking.consent'))
+                    <a href="#" x-data @click.prevent="$dispatch('show-cookie-consent')" class="text-link">{{ __('cookieconsent.preferences') }}</a>
+                    @endif
                 </div>
             </div>
             <div class="lg:hidden flex flex-col gap-5 text-center">

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -2,15 +2,15 @@
     <div class="lg:max-w-7xl lg:mx-auto">
         <div class="flex flex-col gap-10">
             @if(config('tracking.consent'))
-            <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak class="rounded-lg border border-base-300 bg-base-200/50 p-4">
+            <div x-data="footerCookieConsent()" x-show="showConsent" x-cloak class="rounded-xl bg-base-100 p-4">
                 <div class="flex flex-col gap-3 text-sm sm:flex-row sm:items-center">
                     <p class="flex-1 text-neutral-content">
                         {{ __('cookieconsent.message') }}
                         <a href="{{ Domain::toFront('privacy-policy') }}" target="_blank" class="text-link">{{ __('cookieconsent.link') }}</a>
                     </p>
                     <div class="flex shrink-0 gap-2">
-                        <button @click="accept()" class="btn btn-xs btn-primary">{{ __('cookieconsent.allow') }}</button>
-                        <button @click="reject()" class="btn btn-xs btn-ghost">{{ __('cookieconsent.reject') }}</button>
+                        <button @click="accept()" class="btn2 btn-xs btn-primary">{{ __('cookieconsent.allow') }}</button>
+                        <button @click="reject()" class="btn2 btn-xs btn-ghost">{{ __('cookieconsent.reject') }}</button>
                     </div>
                 </div>
             </div>

--- a/resources/views/partials/cookieconsent.blade.php
+++ b/resources/views/partials/cookieconsent.blade.php
@@ -1,24 +1,8 @@
 @inject('countryService', 'App\Services\CountryService')
-@php
-$cookieconsent = [
-    'header' => __('cookieconsent.header'),
-    'message' => __('cookieconsent.message'),
-    'dismiss' => __('cookieconsent.dismiss'),
-    'allow' => __('cookieconsent.allow'),
-    'deny' => __('cookieconsent.reject'),
-    'link' => __('cookieconsent.link'),
-    'href' => 'https://kanka.io/privacy-policy',
-    'close' => '&#x274c;',
-    'policy' => __('cookieconsent.policy'),
-    'target' => '_blank',
-];
-@endphp
 <div
     id="cookieconsent"
     class="hidden"
-    data-api="{{ route('cookieconsent.country') }}"
     data-country="{{ $countryService->getCountry() }}"
-    data-setup='{{ json_encode($cookieconsent) }}'
 @if (!empty(config('tracking.ga'))) data-gtag="{{ config('tracking.ga') }}" @endif
 @if (!empty(config('tracking.gtm'))) data-gtm="{{ config('tracking.gtm') }}" @endif
 ></div>


### PR DESCRIPTION
## Summary

- Replaces the floating `cookieconsent` npm library popup (which obscured mobile content) with a subtle card consent bar embedded at the top of both footer templates
- EU users see the bar on first visit; accept/reject sets a cookie and the bar disappears — cookie name `cookieconsent_status` preserved so existing consent choices are respected
- Non-EU users (detected via Cloudflare `CF-IPCountry`) auto-init tracking with no bar shown, matching the old library's `onNoCookieLaw` behaviour
- Removes the `cookieconsent` npm package entirely

## Test Plan

- [ ] Clear `cookieconsent_status` cookie, visit the app as an EU country (set `data-country` to `FR` via Cloudflare or test env) — consent bar appears above footer link columns
- [ ] Click **Accept** — bar disappears, tracking initialises, cookie set to `allow`; refresh confirms bar stays hidden
- [ ] Clear cookie, click **Reject** — bar disappears, no tracking, cookie set to `deny`; refresh confirms bar stays hidden
- [ ] Simulate non-EU country (e.g. `US`) — bar never appears, tracking auto-inits
- [ ] Verify front (marketing) footer also shows the dark-themed bar under same conditions