### PR TITLE
Feat: Modernise calendars

### DIFF
--- a/app/Http/Controllers/Crud/CalendarController.php
+++ b/app/Http/Controllers/Crud/CalendarController.php
@@ -9,6 +9,7 @@ use App\Models\Calendar;
 use App\Models\Campaign;
 use App\Models\EntityType;
 use App\Sanitizers\CalendarSanitizer;
+use App\Services\Calendars\RecurrenceOptionsService;
 
 class CalendarController extends CrudController
 {
@@ -64,7 +65,7 @@ class CalendarController extends CrudController
         return $this->campaign($campaign)->crudDestroy($calendar);
     }
 
-    public function monthList(Campaign $campaign, Calendar $calendar)
+    public function monthList(Campaign $campaign, Calendar $calendar, RecurrenceOptionsService $recurrenceOptions)
     {
         return response()->json([
             'months' => $calendar->months(),
@@ -73,7 +74,7 @@ class CalendarController extends CrudController
                 'month' => $calendar->currentDate('month'),
                 'day' => $calendar->currentDate('date'),
             ],
-            'recurring' => $calendar->recurringOptions(true),
+            'recurring' => $recurrenceOptions->forApi($calendar),
         ]);
     }
 

--- a/app/Http/Controllers/Widgets/CalendarWidgetController.php
+++ b/app/Http/Controllers/Widgets/CalendarWidgetController.php
@@ -8,18 +8,17 @@ use App\Models\Calendar;
 use App\Models\Campaign;
 use App\Models\CampaignDashboardWidget;
 use App\Services\Calendars\AdvancerService;
-use App\Services\Calendars\ReminderService;
+use App\Services\Calendars\CalendarWidgetStateFactory;
 
 class CalendarWidgetController extends Controller
 {
     protected AdvancerService $service;
 
-    protected ReminderService $reminderService;
-
-    public function __construct(AdvancerService $advancerService, ReminderService $reminderService)
-    {
+    public function __construct(
+        AdvancerService $advancerService,
+        protected CalendarWidgetStateFactory $stateFactory,
+    ) {
         $this->service = $advancerService;
-        $this->reminderService = $reminderService;
     }
 
     public function add(Campaign $campaign, CampaignDashboardWidget $campaignDashboardWidget)
@@ -30,14 +29,13 @@ class CalendarWidgetController extends Controller
             ]);
         }
 
-        /** @var Calendar $calendar */
-        $calendar = $campaignDashboardWidget->entity->child;
+        $entity = $campaignDashboardWidget->entity;
+        $this->authorize('update', $entity);
+        abort_unless($entity->child instanceof Calendar, 404);
+        $calendar = $entity->child;
         $this->service->calendar($calendar)->advance();
 
-        return view('dashboard.widgets.calendar.body')
-            ->with('widget', $campaignDashboardWidget)
-            ->with('calendar', $calendar)
-            ->with('campaign', $campaign);
+        return $this->body($campaign, $campaignDashboardWidget, $calendar);
     }
 
     public function sub(Campaign $campaign, CampaignDashboardWidget $campaignDashboardWidget)
@@ -48,14 +46,13 @@ class CalendarWidgetController extends Controller
             ]);
         }
 
-        /** @var Calendar $calendar */
-        $calendar = $campaignDashboardWidget->entity->child;
+        $entity = $campaignDashboardWidget->entity;
+        $this->authorize('update', $entity);
+        abort_unless($entity->child instanceof Calendar, 404);
+        $calendar = $entity->child;
         $this->service->calendar($calendar)->retreat();
 
-        return view('dashboard.widgets.calendar.body')
-            ->with('widget', $campaignDashboardWidget)
-            ->with('calendar', $calendar)
-            ->with('campaign', $campaign);
+        return $this->body($campaign, $campaignDashboardWidget, $calendar);
     }
 
     public function render(Campaign $campaign, CampaignDashboardWidget $campaignDashboardWidget)
@@ -66,8 +63,19 @@ class CalendarWidgetController extends Controller
             ]);
         }
 
-        return view('dashboard.widgets.calendar.body')
-            ->with('widget', $campaignDashboardWidget)
-            ->with('campaign', $campaign);
+        $entity = $campaignDashboardWidget->entity;
+        abort_unless($entity->child instanceof Calendar, 404);
+
+        return $this->body($campaign, $campaignDashboardWidget, $entity->child);
+    }
+
+    private function body(Campaign $campaign, CampaignDashboardWidget $widget, Calendar $calendar)
+    {
+        return view('dashboard.widgets.calendar.body', [
+            'campaign' => $campaign,
+            'widget' => $widget,
+            'calendar' => $calendar,
+            'state' => $this->stateFactory->make($calendar),
+        ]);
     }
 }

--- a/app/Models/Calendar.php
+++ b/app/Models/Calendar.php
@@ -6,7 +6,9 @@ use App\Models\Concerns\Acl;
 use App\Models\Concerns\HasCampaign;
 use App\Models\Concerns\HasFilters;
 use App\Models\Relations\CalendarRelations;
+use App\Services\Calendars\CalendarChronology;
 use App\Traits\ExportableTrait;
+use App\ValueObjects\Calendars\CalendarDefinition;
 use Exception;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -97,6 +99,8 @@ class Calendar extends MiscModel
     protected array $loadedMonthAliases;
 
     protected array $cachedCurrentDate;
+
+    protected ?CalendarDefinition $cachedDefinition = null;
 
     /**
      * Get the months decoded from the json into a usable array
@@ -436,6 +440,16 @@ class Calendar extends MiscModel
         }
 
         return $days;
+    }
+
+    public function definition(): CalendarDefinition
+    {
+        return $this->cachedDefinition ??= CalendarDefinition::fromCalendar($this);
+    }
+
+    public function chronology(): CalendarChronology
+    {
+        return new CalendarChronology($this->definition());
     }
 
     /**

--- a/app/Models/Calendar.php
+++ b/app/Models/Calendar.php
@@ -151,7 +151,8 @@ class Calendar extends MiscModel
     public function moons(): array
     {
         if (! isset($this->loadedMoons)) {
-            $this->loadedMoons = json_decode(empty($this->moons) ? '[]' : strip_tags($this->moons), true);
+            $moons = $this->attributes['moons'] ?? null;
+            $this->loadedMoons = json_decode(empty($moons) ? '[]' : strip_tags($moons), true);
         }
 
         return $this->loadedMoons;
@@ -396,37 +397,6 @@ class Calendar extends MiscModel
             max($date[1], 1),
             max($date[2], 1),
         ];
-    }
-
-    public function recurringOptions(bool $flat = false): array
-    {
-        $options = [
-            '' => __('calendars.options.events.recurring_periodicity.none'),
-            'month' => __('calendars.options.events.recurring_periodicity.month'),
-            'year' => __('calendars.options.events.recurring_periodicity.year'),
-        ];
-
-        // Add options based on moons
-        $unnamed = 0;
-        foreach ($this->moons() as $moon) {
-            if ($flat) {
-                $options[$moon['id'] . '_f'] = __('calendars.options.events.recurring_periodicity.fullmoon_name', ['moon' => $moon['name']]);
-                $options[$moon['id'] . '_n'] = __('calendars.options.events.recurring_periodicity.newmoon_name', ['moon' => $moon['name']]);
-
-                continue;
-            }
-            $name = $moon['name'];
-            if (empty($name)) {
-                $unnamed++;
-                $name = __('calendars.options.events.recurring_periodicity.unnamed_moon', ['number' => $unnamed]);
-            }
-            $options[$name] = [
-                $moon['id'] . '_f' => __('calendars.options.events.recurring_periodicity.fullmoon'),
-                $moon['id'] . '_n' => __('calendars.options.events.recurring_periodicity.newmoon'),
-            ];
-        }
-
-        return $options;
     }
 
     /**

--- a/app/Renderers/CalendarRenderer.php
+++ b/app/Renderers/CalendarRenderer.php
@@ -384,8 +384,9 @@ class CalendarRenderer
                     $this->dayData['isToday'] = true;
                 }
 
-                if ($this->moonService->has($day)) {
-                    $this->dayData['moons'] = $this->moonService->get($day);
+                $ordinal = $this->calendar->chronology()->toOrdinal(new CalendarDate($this->getYear(), $this->getMonth(), $day));
+                if ($this->moonService->has($ordinal)) {
+                    $this->dayData['moons'] = $this->moonService->get($ordinal);
                 }
 
                 if ($this->weatherService->has($exact)) {
@@ -531,8 +532,9 @@ class CalendarRenderer
                     $this->dayData['isToday'] = true;
                 }
 
-                if ($this->moonService->has($totalDay)) {
-                    $this->dayData['moons'] = $this->moonService->get($totalDay);
+                $ordinal = $this->calendar->chronology()->toOrdinal(new CalendarDate($this->getYear(), $monthNumber, $day));
+                if ($this->moonService->has($ordinal)) {
+                    $this->dayData['moons'] = $this->moonService->get($ordinal);
                 }
                 if ($this->weatherService->has($exact)) {
                     $this->dayData['weather'] = $this->weatherService->get($exact);
@@ -998,20 +1000,13 @@ class CalendarRenderer
 
     protected function buildFullmoons(): void
     {
-        // dump('full moons go brr');
-        // Calculate the number of days since 0000-01-01
-        $totalDays = $this->daysToDate();
-
-        // We'll need this later to know how many full moons to add
-        $daysInAYear = 0;
-        foreach ($this->calendar->months() as $count => $month) {
-            $length = $month['length'];
-            $daysInAYear += $length;
-        }
-
+        $startMonth = $this->isYearlyLayout() ? 1 : $this->getMonth();
+        $endMonth = $this->isYearlyLayout() ? count($this->calendar->months()) : $this->getMonth();
+        $from = new CalendarDate($this->getYear(), $startMonth, 1);
+        $to = new CalendarDate($this->getYear(), $endMonth, $this->calendar->chronology()->daysInMonth($this->getYear(), $endMonth));
         $this->moonService
             ->calendar($this->calendar)
-            ->build($totalDays, $daysInAYear);
+            ->buildForRange($from, $to);
     }
 
     /**

--- a/app/Renderers/CalendarRenderer.php
+++ b/app/Renderers/CalendarRenderer.php
@@ -14,6 +14,7 @@ use App\Services\Calendars\WeatherService;
 use App\Traits\CalendarAware;
 use App\Traits\CampaignAware;
 use App\Traits\RequestAware;
+use App\ValueObjects\Calendars\CalendarDate;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -879,6 +880,13 @@ class CalendarRenderer
     protected function addDay(string $date): string
     {
         [$year, $month, $day] = $this->splitDate($date);
+
+        try {
+            return (string) $this->calendar->chronology()->addDays(new CalendarDate($year, $month, $day), 1);
+        } catch (\InvalidArgumentException) {
+            // Parent-calendar events can use a month that does not exist in the displayed calendar.
+        }
+
         $day++;
 
         // Day longer than month?

--- a/app/Services/Calendars/AdvancerService.php
+++ b/app/Services/Calendars/AdvancerService.php
@@ -4,6 +4,7 @@ namespace App\Services\Calendars;
 
 use App\Jobs\CalendarsClearElapsed;
 use App\Models\Calendar;
+use App\ValueObjects\Calendars\CalendarDate;
 
 class AdvancerService
 {
@@ -21,30 +22,8 @@ class AdvancerService
      */
     public function advance(): self
     {
-        [$year, $month, $day] = $this->calendar->dateArray();
-
-        // Day is longer than month max length?
-        $months = $this->calendar->months();
-        if (! empty($day)) {
-            $day = ((int) $day) + 1;
-            if ($day > $months[$month - 1]['length']) {
-                $day = 1;
-                $month++;
-            }
-        } else {
-            $month++;
-        }
-
-        // Reset month and increment year
-        if ($month > count($months)) {
-            $month = 1;
-            $year++;
-        }
-
-        if (! $this->calendar->hasYearZero() && $year == 0) {
-            $year++;
-        }
-        $this->calendar->date = $year . '-' . $month . ($day !== false ? '-' . $day : null);
+        $date = $this->currentDate();
+        $this->calendar->date = (string) $this->calendar->chronology()->addDays($date, 1);
         $this->calendar->saveQuietly();
 
         return $this;
@@ -55,26 +34,16 @@ class AdvancerService
      */
     public function retreat(): self
     {
-        [$year, $month, $day] = $this->calendar->dateArray();
-
-        $day--;
-        $months = $this->calendar->months();
-        if ($day < 1) {
-            $month--;
-            if ($month < 1) {
-                $month = count($months);
-                $year--;
-            }
-            $day = $months[$month - 1]['length'];
-        }
-
-        if (! $this->calendar->hasYearZero() && $year == 0) {
-            $year--;
-        }
-        $this->calendar->date = $year . '-' . $month . '-' . $day;
+        $date = $this->currentDate();
+        $this->calendar->date = (string) $this->calendar->chronology()->addDays($date, -1);
         $this->calendar->save();
         CalendarsClearElapsed::dispatch($this->calendar);
 
         return $this;
+    }
+
+    private function currentDate(): CalendarDate
+    {
+        return new CalendarDate(...array_map('intval', $this->calendar->dateArray()));
     }
 }

--- a/app/Services/Calendars/CalendarChronology.php
+++ b/app/Services/Calendars/CalendarChronology.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace App\Services\Calendars;
+
+use App\ValueObjects\Calendars\CalendarDate;
+use App\ValueObjects\Calendars\CalendarDefinition;
+use App\ValueObjects\Calendars\LeapRule;
+use InvalidArgumentException;
+
+final class CalendarChronology
+{
+    public function __construct(private readonly CalendarDefinition $definition) {}
+
+    public function definition(): CalendarDefinition
+    {
+        return $this->definition;
+    }
+
+    public function isLeapYear(int $year): bool
+    {
+        foreach ($this->definition->leapRules as $rule) {
+            if ($rule->appliesTo($year)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function isValid(CalendarDate $date): bool
+    {
+        if (! $this->definition->hasYearZero && $date->year === 0) {
+            return false;
+        }
+
+        return $date->month <= $this->definition->monthCount()
+            && $date->day <= $this->daysInMonth($date->year, $date->month);
+    }
+
+    public function daysInMonth(int $year, int $month): int
+    {
+        $length = $this->definition->month($month)['length'];
+
+        foreach ($this->definition->leapRules as $rule) {
+            if ($rule->month === $month && $rule->appliesTo($year)) {
+                $length += $rule->amount;
+            }
+        }
+
+        return $length;
+    }
+
+    public function daysInYear(int $year, bool $includeIntercalary = true): int
+    {
+        $days = 0;
+        foreach ($this->definition->months as $month) {
+            if (! $includeIntercalary && ($month['type'] ?? 'standard') === 'intercalary') {
+                continue;
+            }
+            $days += $month['length'];
+        }
+
+        foreach ($this->definition->leapRules as $rule) {
+            if ($rule->appliesTo($year)
+                && ($includeIntercalary || ! $this->definition->isIntercalary($rule->month))) {
+                $days += $rule->amount;
+            }
+        }
+
+        return $days;
+    }
+
+    /**
+     * Return the zero-based ordinal of a date relative to year 0, day 1.
+     * Calendars without year zero use year 1, day 1 as ordinal zero.
+     */
+    public function toOrdinal(CalendarDate $date, bool $includeIntercalary = true): int
+    {
+        if (! $this->isValid($date)) {
+            throw new InvalidArgumentException("Invalid date for calendar: {$date}");
+        }
+
+        $ordinal = $this->daysBeforeYear($date->year, $includeIntercalary);
+        foreach ($this->definition->months as $index => $month) {
+            $monthNumber = $index + 1;
+            if ($monthNumber >= $date->month) {
+                break;
+            }
+            if ($includeIntercalary || ($month['type'] ?? 'standard') !== 'intercalary') {
+                $ordinal += $month['length'];
+            }
+        }
+
+        foreach ($this->definition->leapRules as $rule) {
+            if ($rule->appliesTo($date->year)
+                && $rule->month < $date->month
+                && ($includeIntercalary || ! $this->definition->isIntercalary($rule->month))) {
+                $ordinal += $rule->amount;
+            }
+        }
+
+        return $ordinal + $date->day - 1;
+    }
+
+    public function fromOrdinal(int $ordinal, bool $includeIntercalary = true): CalendarDate
+    {
+        $serial = $this->yearSerialForOrdinal($ordinal, $includeIntercalary);
+        $year = $this->yearFromSerial($serial);
+        $dayOfYear = $ordinal - $this->daysBeforeSerial($serial, $includeIntercalary);
+
+        foreach ($this->definition->months as $index => $month) {
+            $monthNumber = $index + 1;
+            if (! $includeIntercalary && ($month['type'] ?? 'standard') === 'intercalary') {
+                continue;
+            }
+
+            $length = $this->daysInMonth($year, $monthNumber);
+            if (! $includeIntercalary && $this->definition->isIntercalary($monthNumber)) {
+                $length = 0;
+            }
+            if ($dayOfYear < $length) {
+                return new CalendarDate($year, $monthNumber, $dayOfYear + 1);
+            }
+            $dayOfYear -= $length;
+        }
+
+        throw new InvalidArgumentException("Unable to convert ordinal {$ordinal} to a calendar date.");
+    }
+
+    public function addDays(CalendarDate $date, int $days): CalendarDate
+    {
+        return $this->fromOrdinal($this->toOrdinal($date) + $days);
+    }
+
+    public function addMonths(CalendarDate $date, int $months, string $invalidDate = 'skip'): ?CalendarDate
+    {
+        $serial = $this->monthSerial($date->year, $date->month) + $months;
+        $yearSerial = self::floorDiv($serial, $this->definition->monthCount());
+        $month = $serial - ($yearSerial * $this->definition->monthCount()) + 1;
+        $year = $this->yearFromSerial($yearSerial);
+        $day = $date->day;
+        $length = $this->daysInMonth($year, $month);
+
+        if ($day > $length) {
+            if ($invalidDate === 'skip') {
+                return null;
+            }
+            if ($invalidDate !== 'clamp') {
+                throw new InvalidArgumentException("Unknown invalid-date policy: {$invalidDate}");
+            }
+            $day = $length;
+        }
+
+        return new CalendarDate($year, $month, $day);
+    }
+
+    public function addYears(CalendarDate $date, int $years, string $invalidDate = 'skip'): ?CalendarDate
+    {
+        $year = $this->yearFromSerial($this->yearSerial($date->year) + $years);
+        $day = $date->day;
+        $length = $this->daysInMonth($year, $date->month);
+
+        if ($day > $length) {
+            if ($invalidDate === 'skip') {
+                return null;
+            }
+            if ($invalidDate !== 'clamp') {
+                throw new InvalidArgumentException("Unknown invalid-date policy: {$invalidDate}");
+            }
+            $day = $length;
+        }
+
+        return new CalendarDate($year, $date->month, $day);
+    }
+
+    public function weekdayIndex(CalendarDate $date): int
+    {
+        $weekdays = $this->definition->weekdayCount();
+        $weekday = ($this->toOrdinal($date) + $this->definition->startOffset) % $weekdays;
+
+        return $weekday < 0 ? $weekday + $weekdays : $weekday;
+    }
+
+    public function dayOfYear(CalendarDate $date): int
+    {
+        return $this->toOrdinal($date) - $this->daysBeforeYear($date->year, true) + 1;
+    }
+
+    private function daysBeforeYear(int $year, bool $includeIntercalary): int
+    {
+        return $this->daysBeforeSerial($this->yearSerial($year), $includeIntercalary);
+    }
+
+    private function daysBeforeSerial(int $serial, bool $includeIntercalary): int
+    {
+        $base = $this->baseDaysInYear($includeIntercalary);
+        $days = $base * $serial;
+
+        foreach ($this->definition->leapRules as $rule) {
+            if (! $includeIntercalary && $this->definition->isIntercalary($rule->month)) {
+                continue;
+            }
+            $days += $rule->amount * $this->leapYearsBeforeSerial($rule, $serial);
+        }
+
+        return $days;
+    }
+
+    private function baseDaysInYear(bool $includeIntercalary): int
+    {
+        $days = 0;
+        foreach ($this->definition->months as $month) {
+            if ($includeIntercalary || ($month['type'] ?? 'standard') !== 'intercalary') {
+                $days += $month['length'];
+            }
+        }
+
+        return $days;
+    }
+
+    private function leapYearsBeforeSerial(LeapRule $rule, int $serial): int
+    {
+        if ($serial === 0) {
+            return 0;
+        }
+
+        if ($this->definition->hasYearZero) {
+            return $serial > 0
+                ? $this->countRule($rule, 0, $serial - 1)
+                : -$this->countRule($rule, $serial, -1);
+        }
+
+        return $serial > 0
+            ? $this->countRule($rule, 1, $serial)
+            : -$this->countRule($rule, $serial, -1);
+    }
+
+    private function countRule(LeapRule $rule, int $from, int $to): int
+    {
+        if ($from > $to || $to < $rule->startYear) {
+            return 0;
+        }
+        $from = max($from, $rule->startYear);
+        if ($from > $to) {
+            return 0;
+        }
+
+        $first = $rule->startYear + self::ceilDiv($from - $rule->startYear, $rule->interval) * $rule->interval;
+
+        return $first > $to ? 0 : intdiv($to - $first, $rule->interval) + 1;
+    }
+
+    private function yearSerial(int $year): int
+    {
+        if ($this->definition->hasYearZero) {
+            return $year;
+        }
+
+        if ($year === 0) {
+            throw new InvalidArgumentException('This calendar does not have a year zero.');
+        }
+
+        return $year > 0 ? $year - 1 : $year;
+    }
+
+    private function yearFromSerial(int $serial): int
+    {
+        if ($this->definition->hasYearZero || $serial < 0) {
+            return $serial;
+        }
+
+        return $serial + 1;
+    }
+
+    private function monthSerial(int $year, int $month): int
+    {
+        return $this->yearSerial($year) * $this->definition->monthCount() + $month - 1;
+    }
+
+    private function yearSerialForOrdinal(int $ordinal, bool $includeIntercalary): int
+    {
+        $base = max(1, $this->baseDaysInYear($includeIntercalary));
+        $estimate = self::floorDiv($ordinal, $base);
+        $low = $estimate;
+        $high = $estimate;
+        $step = 1;
+
+        while ($this->daysBeforeSerial($low, $includeIntercalary) > $ordinal) {
+            $low -= $step;
+            $step *= 2;
+        }
+        $step = 1;
+        while ($this->daysBeforeSerial($high + 1, $includeIntercalary) <= $ordinal) {
+            $high += $step;
+            $step *= 2;
+        }
+
+        while ($low < $high) {
+            $middle = $low + intdiv($high - $low + 1, 2);
+            if ($this->daysBeforeSerial($middle, $includeIntercalary) <= $ordinal) {
+                $low = $middle;
+            } else {
+                $high = $middle - 1;
+            }
+        }
+
+        return $low;
+    }
+
+    private static function floorDiv(int $numerator, int $denominator): int
+    {
+        if ($numerator >= 0) {
+            return intdiv($numerator, $denominator);
+        }
+
+        return -intdiv(-$numerator + $denominator - 1, $denominator);
+    }
+
+    private static function ceilDiv(int $numerator, int $denominator): int
+    {
+        return -self::floorDiv(-$numerator, $denominator);
+    }
+}

--- a/app/Services/Calendars/CalendarWidgetStateFactory.php
+++ b/app/Services/Calendars/CalendarWidgetStateFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Calendars;
+
+use App\Models\Calendar;
+use App\ValueObjects\Calendars\CalendarDate;
+use App\ValueObjects\Calendars\CalendarWidgetState;
+
+final class CalendarWidgetStateFactory
+{
+    public function __construct(private readonly ReminderService $reminders) {}
+
+    public function make(Calendar $calendar): CalendarWidgetState
+    {
+        $date = new CalendarDate($calendar->currentYear(), $calendar->currentMonth(), $calendar->currentDay());
+        $chronology = $calendar->chronology();
+        $window = $this->reminders->calendar($calendar)->around(5);
+        $weather = $calendar->calendarWeather()
+            ->year($date->year)
+            ->month($date->month)
+            ->where('day', $date->day)
+            ->first();
+        $weekdays = $calendar->weekdays();
+
+        return new CalendarWidgetState(
+            $window->past,
+            $window->upcoming,
+            (new MoonPhaseCalculator($chronology))->statesAt($date),
+            $weekdays[$chronology->weekdayIndex($date)] ?? null,
+            $weather,
+        );
+    }
+}

--- a/app/Services/Calendars/DaysService.php
+++ b/app/Services/Calendars/DaysService.php
@@ -3,7 +3,7 @@
 namespace App\Services\Calendars;
 
 use App\Traits\CalendarAware;
-use Illuminate\Support\Arr;
+use App\ValueObjects\Calendars\CalendarDate;
 
 class DaysService
 {
@@ -47,61 +47,9 @@ class DaysService
 
     public function daysToDate(): int
     {
-        // We assume that the 01 01 00 is a monday.
-        // We need to know how many days elapsed since that day, to calculate the offset (total days / week length)
-
-        $daysInAYear = $days = $leapDays = 0;
-        foreach ($this->calendar->months() as $count => $month) {
-            if (! $this->intercalary && Arr::get($month, 'type') == 'intercalary') {
-                continue;
-            }
-            $length = $month['length'];
-            $daysInAYear += $length;
-
-            // If the month has already passed, add it to the days for this year
-            if ($count < $this->month - 1) {
-                $days += $length;
-            }
-        }
-
-        if ($this->calendar->has_leap_year && $this->year >= $this->calendar->leap_year_start) {
-            // If the leap month is intercalary, we don't need to offset anything.
-            $months = $this->calendar->months();
-            $leapMonth = Arr::get($months, $this->calendar->leap_year_month - 1, false);
-            if ($leapMonth && Arr::get($leapMonth, 'type') == 'intercalary') {
-                // Nothing
-            } else {
-                // Calc the number of years that were leap years
-                //            dump("the current year (" . $this->getYear() . ") is >= to when the calendar leap year starts
-                //               (" . $this->calendar->leap_year_start . ")");
-                $yearDiffWithLeapStart = $this->year - $this->calendar->leap_year_start;
-                $amountOfYears = ceil($yearDiffWithLeapStart / max(1, $this->calendar->leap_year_offset));
-                //            dump ("the amount of leap years that has elapsed since the beginning is the following: $amountOfYears");
-                //            dump ("the value is ceil((" . $this->getYear() . "-" . $this->calendar->leap_year_start . ")
-                //               / " . $this->calendar->leap_year_offset . ")");
-                if ($amountOfYears < 0) {
-                    $amountOfYears = 0;
-                }
-
-                $leapDays = $amountOfYears * $this->calendar->leap_year_amount;
-
-                //            dump ("total leap days elapsed: $leapDays");
-
-                // But if we are a leap year, we need to do the math
-                if (($this->year - $this->calendar->leap_year_start) % max($this->calendar->leap_year_offset, 1) == 0) {
-                    if ($this->month > $this->calendar->leap_year_month) {
-                        // We've passed the leap month of the year
-                        $leapDays += $this->calendar->leap_year_amount;
-                    }
-                }
-            }
-        }
-
-        // Number of days since the beginning of the year
-        if (! $this->calendar->hasYearZero() && $this->year > 0) {
-            return ($daysInAYear * ($this->year - 1)) + $days + $leapDays;
-        }
-
-        return ($daysInAYear * $this->year) + $days + $leapDays;
+        return $this->calendar->chronology()->toOrdinal(
+            new CalendarDate($this->year, $this->month, 1),
+            $this->intercalary,
+        );
     }
 }

--- a/app/Services/Calendars/LegacyRecurrenceAdapter.php
+++ b/app/Services/Calendars/LegacyRecurrenceAdapter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services\Calendars;
+
+use App\Models\Reminder;
+use App\ValueObjects\Calendars\RecurrenceRule;
+use InvalidArgumentException;
+
+final class LegacyRecurrenceAdapter
+{
+    public function fromReminder(Reminder $reminder): ?RecurrenceRule
+    {
+        $periodicity = (string) ($reminder->recurring_periodicity ?? '');
+        if ($periodicity === '') {
+            return null;
+        }
+
+        $untilYear = $reminder->recurring_until;
+        if ($untilYear !== null && $untilYear !== '' && ! is_numeric($untilYear)) {
+            throw new InvalidArgumentException("Invalid recurrence end year: {$untilYear}");
+        }
+        $untilYear = $untilYear === null || $untilYear === '' ? null : (int) $untilYear;
+
+        return match ($periodicity) {
+            'month' => new RecurrenceRule(RecurrenceRule::MONTHLY, untilYear: $untilYear),
+            'year' => new RecurrenceRule(RecurrenceRule::YEARLY, untilYear: $untilYear),
+            default => $this->moonRule($periodicity, $untilYear),
+        };
+    }
+
+    private function moonRule(string $periodicity, ?int $untilYear): RecurrenceRule
+    {
+        if (! preg_match('/^(\d+)_(f|n)$/', $periodicity, $parts)) {
+            throw new InvalidArgumentException("Unsupported legacy recurrence: {$periodicity}");
+        }
+
+        return new RecurrenceRule(
+            RecurrenceRule::MOON_PHASE,
+            untilYear: $untilYear,
+            moonId: (int) $parts[1],
+            phase: $parts[2] === 'f' ? 'full' : 'new',
+        );
+    }
+}

--- a/app/Services/Calendars/LegacyRecurrenceAdapter.php
+++ b/app/Services/Calendars/LegacyRecurrenceAdapter.php
@@ -10,6 +10,10 @@ final class LegacyRecurrenceAdapter
 {
     public function fromReminder(Reminder $reminder): ?RecurrenceRule
     {
+        if (! (bool) $reminder->is_recurring) {
+            return null;
+        }
+
         $periodicity = (string) ($reminder->recurring_periodicity ?? '');
         if ($periodicity === '') {
             return null;

--- a/app/Services/Calendars/MoonPhaseCalculator.php
+++ b/app/Services/Calendars/MoonPhaseCalculator.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace App\Services\Calendars;
+
+use App\ValueObjects\Calendars\CalendarDate;
+use App\ValueObjects\Calendars\MoonPhaseOccurrence;
+use App\ValueObjects\Calendars\MoonState;
+use InvalidArgumentException;
+
+final class MoonPhaseCalculator
+{
+    private const SCALE = 10000000000;
+
+    /** @var array<string, int> */
+    private const PHASES = [
+        'full' => 0,
+        'last_quarter' => 1,
+        'new' => 2,
+        'first_quarter' => 3,
+    ];
+
+    public function __construct(private readonly CalendarChronology $chronology) {}
+
+    /** @return list<MoonState> */
+    public function statesAt(CalendarDate $date): array
+    {
+        $ordinal = $this->chronology->toOrdinal($date);
+        $states = [];
+
+        foreach ($this->chronology->definition()->moons as $moon) {
+            $id = (int) ($moon['id'] ?? 0);
+            $cycle = $this->decimalTicks($moon['fullmoon'] ?? 0);
+            if ($id < 1 || $cycle <= 0) {
+                continue;
+            }
+
+            $latest = $this->latestPhase($moon, $ordinal, $cycle);
+            $states[] = new MoonState(
+                $id,
+                (string) ($moon['name'] ?? ''),
+                $this->colour((string) ($moon['colour'] ?? 'grey')),
+                $latest->phase,
+                $latest->date,
+                $ordinal - $latest->ordinal,
+                $latest->exactPhases,
+            );
+        }
+
+        return $states;
+    }
+
+    /** @return list<MoonPhaseOccurrence> */
+    public function phasesBetween(CalendarDate $from, CalendarDate $to): array
+    {
+        $fromOrdinal = $this->chronology->toOrdinal($from);
+        $toOrdinal = $this->chronology->toOrdinal($to);
+        if ($fromOrdinal > $toOrdinal) {
+            throw new InvalidArgumentException('Moon phase range is invalid.');
+        }
+
+        $phases = [];
+        foreach ($this->chronology->definition()->moons as $moon) {
+            $id = (int) ($moon['id'] ?? 0);
+            $cycle = $this->decimalTicks($moon['fullmoon'] ?? 0);
+            if ($id < 1 || $cycle <= 0) {
+                continue;
+            }
+
+            foreach (self::PHASES as $phase => $phaseIndex) {
+                $phaseCount = count(self::PHASES);
+                $denominator = $phaseCount * self::SCALE;
+                $base = $this->decimalTicks($moon['offset'] ?? 0) * $phaseCount;
+                $step = $cycle * $phaseCount;
+                $phaseBase = $base + ($phaseIndex * $cycle);
+                $firstCycle = self::ceilDiv($fromOrdinal * $denominator - $phaseBase, $step);
+                $lastCycle = self::floorDiv((($toOrdinal + 1) * $denominator - 1) - $phaseBase, $step);
+
+                for ($cycleNumber = $firstCycle; $cycleNumber <= $lastCycle; $cycleNumber++) {
+                    $ordinal = self::floorDiv($phaseBase + ($cycleNumber * $step), $denominator);
+                    $date = $this->chronology->fromOrdinal($ordinal);
+                    $phases[] = new MoonPhaseOccurrence(
+                        $id,
+                        (string) ($moon['name'] ?? ''),
+                        $this->colour((string) ($moon['colour'] ?? 'grey')),
+                        $phase,
+                        $date,
+                        $ordinal,
+                        [$phase],
+                    );
+                }
+            }
+        }
+
+        usort($phases, static fn (MoonPhaseOccurrence $a, MoonPhaseOccurrence $b): int => $a->ordinal <=> $b->ordinal);
+
+        return $this->mergeExactPhases($phases);
+    }
+
+    /** @param array<string, mixed> $moon */
+    private function latestPhase(array $moon, int $ordinal, int $cycle): MoonPhaseOccurrence
+    {
+        $phaseCount = count(self::PHASES);
+        $denominator = $phaseCount * self::SCALE;
+        $offset = $this->decimalTicks($moon['offset'] ?? 0);
+        $step = $cycle * $phaseCount;
+        $latest = null;
+        $latestBoundary = null;
+
+        foreach (self::PHASES as $phase => $phaseIndex) {
+            $phaseBase = $offset * $phaseCount + ($phaseIndex * $cycle);
+            $cycleNumber = self::floorDiv($ordinal * $denominator - $phaseBase, $step);
+            $boundary = $phaseBase + ($cycleNumber * $step);
+            $phaseOrdinal = self::floorDiv($boundary, $denominator);
+            if ($phaseOrdinal > $ordinal) {
+                $cycleNumber--;
+                $boundary -= $step;
+                $phaseOrdinal = self::floorDiv($boundary, $denominator);
+            }
+
+            if ($latest === null || $phaseOrdinal > $latest->ordinal || ($phaseOrdinal === $latest->ordinal && $boundary > $latestBoundary)) {
+                $latest = new MoonPhaseOccurrence(
+                    (int) ($moon['id'] ?? 0),
+                    (string) ($moon['name'] ?? ''),
+                    $this->colour((string) ($moon['colour'] ?? 'grey')),
+                    $phase,
+                    $this->chronology->fromOrdinal($phaseOrdinal),
+                    $phaseOrdinal,
+                    [$phase],
+                );
+                $latestBoundary = $boundary;
+            }
+        }
+
+        $exact = [];
+        foreach (self::PHASES as $phase => $phaseIndex) {
+            $phaseBase = $offset * $phaseCount + ($phaseIndex * $cycle);
+            $cycleNumber = self::floorDiv($ordinal * $denominator - $phaseBase, $step);
+            $phaseOrdinal = self::floorDiv($phaseBase + ($cycleNumber * $step), $denominator);
+            if ($phaseOrdinal === $latest->ordinal) {
+                $exact[] = $phase;
+            }
+        }
+
+        return new MoonPhaseOccurrence(
+            $latest->moonId,
+            $latest->name,
+            $latest->colour,
+            $latest->phase,
+            $latest->date,
+            $latest->ordinal,
+            $exact,
+        );
+    }
+
+    /** @param list<MoonPhaseOccurrence> $phases */
+    /** @return list<MoonPhaseOccurrence> */
+    private function mergeExactPhases(array $phases): array
+    {
+        $merged = [];
+        foreach ($phases as $phase) {
+            $key = $phase->moonId . ':' . $phase->ordinal;
+            if (! isset($merged[$key])) {
+                $merged[$key] = $phase;
+
+                continue;
+            }
+            $existing = $merged[$key];
+            $merged[$key] = new MoonPhaseOccurrence(
+                $existing->moonId,
+                $existing->name,
+                $existing->colour,
+                $existing->phase,
+                $existing->date,
+                $existing->ordinal,
+                [...$existing->exactPhases, $phase->phase],
+            );
+        }
+
+        return array_values($merged);
+    }
+
+    private function decimalTicks(float|int|string $value): int
+    {
+        $value = trim((string) $value);
+        if (! preg_match('/^-?\d+(?:\.\d{1,10})?$/', $value)) {
+            throw new InvalidArgumentException("Invalid moon cycle value: {$value}");
+        }
+
+        $negative = str_starts_with($value, '-');
+        $value = ltrim($value, '-');
+        [$whole, $fraction] = array_pad(explode('.', $value, 2), 2, '');
+        $ticks = ((int) $whole * self::SCALE) + (int) str_pad($fraction, 10, '0');
+
+        return $negative ? -$ticks : $ticks;
+    }
+
+    private function colour(string $colour): string
+    {
+        return match ($colour) {
+            'aqua' => '#3B82F6',
+            'black' => '#000000',
+            'brown' => '#7C2D12',
+            'green' => '#22C55E',
+            'light-blue' => '#93C5FD',
+            'maroon' => '#9D174D',
+            'navy' => '#1E3A8A',
+            'orange' => '#F97316',
+            'pink' => '#EC4899',
+            'purple' => '#A855F7',
+            'red' => '#EF4444',
+            'teal' => '#14B8A6',
+            'yellow' => '#EAB308',
+            'grey' => '#6B7280',
+            default => $colour,
+        };
+    }
+
+    private static function floorDiv(int $numerator, int $denominator): int
+    {
+        if ($numerator >= 0) {
+            return intdiv($numerator, $denominator);
+        }
+
+        return -intdiv(-$numerator + $denominator - 1, $denominator);
+    }
+
+    private static function ceilDiv(int $numerator, int $denominator): int
+    {
+        return -self::floorDiv(-$numerator, $denominator);
+    }
+}

--- a/app/Services/Calendars/MoonService.php
+++ b/app/Services/Calendars/MoonService.php
@@ -3,131 +3,62 @@
 namespace App\Services\Calendars;
 
 use App\Traits\CalendarAware;
-use Illuminate\Support\Arr;
+use App\ValueObjects\Calendars\CalendarDate;
 
 class MoonService
 {
     use CalendarAware;
 
+    /** @var array<int, list<array<string, mixed>>> */
     protected array $moons = [];
 
-    public function has(int $day): bool
+    public function has(int $ordinal): bool
     {
-        return isset($this->moons[$day]);
+        return isset($this->moons[$ordinal]);
     }
 
-    public function get(int $day): array
+    /** @return list<array<string, mixed>> */
+    public function get(int $ordinal): array
     {
-        return $this->moons[$day] ?? [];
+        return $this->moons[$ordinal] ?? [];
     }
 
+    /**
+     * Compatibility wrapper for callers that provide an ordinal and a year length.
+     */
     public function build(int $totalDays, int $daysInAYear): void
     {
-        foreach ($this->calendar->moons() as $moon) {
-            $fullmoon = $moon['fullmoon'];
-            // Let's figure out how many full moons occurred until now
-            $numberOfFullMoons = $totalDays / $fullmoon;
+        $from = $this->calendar->chronology()->fromOrdinal($totalDays);
+        $to = $this->calendar->chronology()->fromOrdinal($totalDays + max(0, $daysInAYear - 1));
 
-            // When was the last full moon?
-            $lastFullMoon = floor($numberOfFullMoons) * $fullmoon;
+        $this->buildForRange($from, $to);
+    }
 
-            // Use that to see how many days it's been
-            $daysSinceLastFullMoon = round($totalDays - $lastFullMoon, 2);
+    public function buildForRange(CalendarDate $from, CalendarDate $to): void
+    {
+        $this->moons = [];
+        $calculator = new MoonPhaseCalculator($this->calendar->chronology());
 
-            // Next full moon? If it's 0, we want it today.
-            $nextFullMoon = (1 + $moon['offset']) + ($fullmoon - ($daysSinceLastFullMoon == 0 ? $fullmoon : $daysSinceLastFullMoon));
-
-            // Previous cycles. Twice because sometimes the first full moon appears at the end of a long month, so
-            // we need to fill up the month as much as we can.
-            // With a big enough offset and fullmoon cycle, the user can end up with no moon on their first month of
-            // the first year?
-            $maxCycles = max(2, 3);
-            for ($cycles = 1; $cycles <= $maxCycles; $cycles++) {
-                $this->addPhases($nextFullMoon - ($moon['fullmoon'] * $cycles), $moon);
-            }
-
-            // Current cycles
-            $this->addPhases($nextFullMoon, $moon);
-
-            // Now the full moon will appear several times on this month/year.
-            $fullMoonsPerYear = ceil($daysInAYear / $fullmoon);
-            for ($i = 0; $i < $fullMoonsPerYear; $i++) {
-                $nextFullMoon += $fullmoon;
-                $this->addPhases($nextFullMoon, $moon);
-            }
+        foreach ($calculator->phasesBetween($from, $to) as $phase) {
+            $this->moons[$phase->ordinal][] = [
+                'name' => $phase->name,
+                'type' => $phase->phase === 'first_quarter' ? '1first_quarter' : $phase->phase,
+                'phase' => $phase->phase,
+                'class' => $this->phaseClass($phase->phase),
+                'colour' => $phase->colour,
+                'id' => $phase->moonId,
+            ];
         }
     }
 
-    protected function addPhases(float $start, array $moon): void
+    private function phaseClass(string $phase): string
     {
-        // Full & New Moon
-        $this->addPhase($start, $moon, 'full', 'far fa-circle');
-        $newMoon = $start + ($moon['fullmoon'] / 2);
-        $this->addPhase($newMoon, $moon, 'new', 'fa-solid fa-circle');
-
-        if ($moon['fullmoon'] <= 10) {
-            return;
-        }
-        // Cycle is long enough for more phases to be displayed
-        $quarterMonth = $moon['fullmoon'] / 4;
-        $this->addPhase($newMoon - $quarterMonth, $moon, 'last_quarter', 'fa-solid fa-circle-half-stroke fa-flip-horizontal');
-        $this->addPhase($newMoon + $quarterMonth, $moon, '1first_quarter', 'fa-solid fa-circle-half-stroke');
-    }
-
-    protected function addPhase(float $nextFullMoon, array $moon, string $type = 'full', string $class = 'fa-regular fa-circle'): void
-    {
-        // Moons can be float so we "floor" them
-        $nextFullMoon = (int) floor($nextFullMoon);
-
-        // If the next full moon is before year 0... What?
-        if ($nextFullMoon < 0) {
-            // return;
-        }
-        if (! isset($this->moons[$nextFullMoon])) {
-            $this->moons[$nextFullMoon] = [];
-        }
-        $this->moons[$nextFullMoon][] = [
-            'name' => $moon['name'],
-            'type' => $type,
-            'class' => $class,
-            'colour' => $this->colour(Arr::get($moon, 'colour', 'grey')),
-            'id' => Arr::get($moon, 'id', null),
-        ];
-    }
-
-    protected function colour(string $colour): string
-    {
-        switch ($colour) {
-            case 'aqua':
-                return '#3B82F6'; // blue-500
-            case 'black':
-                return '#000000'; // black
-            case 'brown':
-                return '#7C2D12'; // orange-900 (closest brown)
-            case 'green':
-                return '#22C55E'; // green-500
-            case 'light-blue':
-                return '#93C5FD'; // blue-300
-            case 'maroon':
-                return '#9D174D'; // pink-800 (closest maroon)
-            case 'navy':
-                return '#1E3A8A'; // blue-900
-            case 'orange':
-                return '#F97316'; // orange-500
-            case 'pink':
-                return '#EC4899'; // pink-500
-            case 'purple':
-                return '#A855F7'; // purple-500
-            case 'red':
-                return '#EF4444'; // red-500
-            case 'teal':
-                return '#14B8A6'; // teal-500
-            case 'yellow':
-                return '#EAB308'; // yellow-500
-            case 'grey':
-                return '#6B7280'; // gray-500
-        }
-
-        return $colour;
+        return match ($phase) {
+            'full' => 'fa-regular fa-circle',
+            'new' => 'fa-solid fa-circle',
+            'last_quarter' => 'fa-solid fa-circle-half-stroke fa-flip-horizontal',
+            'first_quarter' => 'fa-solid fa-circle-half-stroke',
+            default => 'fa-regular fa-circle',
+        };
     }
 }

--- a/app/Services/Calendars/OccurrenceEngine.php
+++ b/app/Services/Calendars/OccurrenceEngine.php
@@ -9,7 +9,14 @@ use InvalidArgumentException;
 
 final class OccurrenceEngine
 {
-    public function __construct(private readonly CalendarChronology $chronology) {}
+    private readonly MoonPhaseCalculator $moonPhases;
+
+    public function __construct(
+        private readonly CalendarChronology $chronology,
+        ?MoonPhaseCalculator $moonPhases = null,
+    ) {
+        $this->moonPhases = $moonPhases ?? new MoonPhaseCalculator($chronology);
+    }
 
     /**
      * Generate occurrences intersecting an inclusive date window.
@@ -76,12 +83,10 @@ final class OccurrenceEngine
     /** @return list<Occurrence> */
     private function monthlyOccurrences(CalendarDate $anchor, int $length, RecurrenceRule $rule, CalendarDate $from, CalendarDate $to): array
     {
-        $targetSerial = $this->chronology->toOrdinal($from);
-        $monthDistance = $this->monthSerial($from) - $this->monthSerial($anchor);
+        $earliestStart = $this->chronology->fromOrdinal($this->chronology->toOrdinal($from) - ($length - 1));
+        $targetSerial = $this->chronology->toOrdinal($earliestStart);
+        $monthDistance = $this->monthSerial($earliestStart) - $this->monthSerial($anchor);
         $sequence = max(0, self::ceilDiv($monthDistance, $rule->interval));
-        if ($this->chronology->toOrdinal($anchor) + $length - 1 >= $targetSerial) {
-            $sequence = 0;
-        }
         $occurrences = [];
 
         while (true) {
@@ -97,11 +102,9 @@ final class OccurrenceEngine
             if ($this->pastUntil($candidate, $rule) || $candidate->compare($to) > 0) {
                 break;
             }
-            if ($this->chronology->toOrdinal($candidate) + $length - 1 >= $targetSerial) {
-                $occurrence = $this->makeOccurrence($candidate, $length, $sequence, $from, $to);
-                if ($occurrence !== null) {
-                    $occurrences[] = $occurrence;
-                }
+            $occurrence = $this->makeOccurrence($candidate, $length, $sequence, $from, $to);
+            if ($occurrence !== null) {
+                $occurrences[] = $occurrence;
             }
             $sequence++;
         }
@@ -112,11 +115,9 @@ final class OccurrenceEngine
     /** @return list<Occurrence> */
     private function yearlyOccurrences(CalendarDate $anchor, int $length, RecurrenceRule $rule, CalendarDate $from, CalendarDate $to): array
     {
-        $yearDistance = $this->yearSerial($from->year) - $this->yearSerial($anchor->year);
+        $earliestStart = $this->chronology->fromOrdinal($this->chronology->toOrdinal($from) - ($length - 1));
+        $yearDistance = $this->yearSerial($earliestStart->year) - $this->yearSerial($anchor->year);
         $sequence = max(0, self::ceilDiv($yearDistance, $rule->interval));
-        if ($this->chronology->toOrdinal($anchor) + $length - 1 >= $this->chronology->toOrdinal($from)) {
-            $sequence = 0;
-        }
         $occurrences = [];
 
         while (true) {
@@ -150,24 +151,16 @@ final class OccurrenceEngine
             throw new InvalidArgumentException("Unknown moon: {$rule->moonId}");
         }
 
-        $cycle = (float) $moon['fullmoon'];
-        $phaseOffset = $rule->phase === 'new' ? $cycle / 2 : 0;
-        $start = $this->chronology->toOrdinal($from) - ($length - 1);
-        $end = $this->chronology->toOrdinal($to);
         $anchorOrdinal = $this->chronology->toOrdinal($anchor);
-        $firstCycle = (int) floor(($start - (float) ($moon['offset'] ?? 0) - $phaseOffset) / $cycle) - 1;
-        $lastCycle = (int) ceil(($end - (float) ($moon['offset'] ?? 0) - $phaseOffset) / $cycle) + 1;
         $occurrences = [];
         $sequence = 0;
-        $seen = [];
 
-        for ($cycleNumber = $firstCycle; $cycleNumber <= $lastCycle; $cycleNumber++) {
-            $ordinal = (int) floor((float) ($moon['offset'] ?? 0) + $phaseOffset + ($cycleNumber * $cycle));
-            if ($ordinal < $anchorOrdinal || isset($seen[$ordinal])) {
+        $earliestStart = $this->chronology->fromOrdinal($this->chronology->toOrdinal($from) - ($length - 1));
+        foreach ($this->moonPhases->phasesBetween($earliestStart, $to) as $phase) {
+            if ($phase->moonId !== $rule->moonId || ! in_array($rule->phase, $phase->exactPhases, true) || $phase->ordinal < $anchorOrdinal) {
                 continue;
             }
-            $seen[$ordinal] = true;
-            $candidate = $this->chronology->fromOrdinal($ordinal);
+            $candidate = $phase->date;
             if ($this->pastUntil($candidate, $rule) || $candidate->compare($to) > 0) {
                 continue;
             }
@@ -182,6 +175,101 @@ final class OccurrenceEngine
         return $occurrences;
     }
 
+    public function nextOrActiveOccurrence(
+        CalendarDate $anchor,
+        int $length,
+        ?RecurrenceRule $rule,
+        CalendarDate $pivot,
+    ): ?Occurrence {
+        $this->validate($anchor, $length, $pivot);
+        $pivotOrdinal = $this->chronology->toOrdinal($pivot);
+
+        if ($rule === null) {
+            return $this->occurrenceIf($anchor, $length, static fn (Occurrence $occurrence): bool => $occurrence->end->compare($pivot) >= 0);
+        }
+
+        if ($rule->frequency === RecurrenceRule::MOON_PHASE) {
+            $earliestStart = $this->chronology->fromOrdinal($pivotOrdinal - ($length - 1));
+            foreach ($this->moonPhases->phasesBetween($earliestStart, $this->chronology->fromOrdinal($pivotOrdinal + $this->searchLimit($rule))) as $phase) {
+                if ($phase->moonId === $rule->moonId && in_array($rule->phase, $phase->exactPhases, true)) {
+                    $occurrence = $this->buildOccurrence($phase->date, $length, 0);
+                    if (! $this->pastUntil($occurrence->start, $rule) && $occurrence->end->compare($pivot) >= 0 && $occurrence->start->compare($anchor) >= 0) {
+                        return $occurrence;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        $sequence = $this->firstSequenceAtOrAfter($anchor, $length, $rule, $pivot, false);
+        for ($attempt = 0; $attempt < 100000; $attempt++) {
+            $candidate = $this->candidateAt($anchor, $rule, $sequence);
+            if ($candidate === null) {
+                $sequence++;
+
+                continue;
+            }
+            if ($this->pastUntil($candidate, $rule)) {
+                return null;
+            }
+            $occurrence = $this->buildOccurrence($candidate, $length, $sequence);
+            if ($occurrence->end->compare($pivot) >= 0) {
+                return $occurrence;
+            }
+            $sequence++;
+        }
+
+        return null;
+    }
+
+    public function previousOccurrence(
+        CalendarDate $anchor,
+        int $length,
+        ?RecurrenceRule $rule,
+        CalendarDate $pivot,
+    ): ?Occurrence {
+        $this->validate($anchor, $length, $pivot);
+        $pivotOrdinal = $this->chronology->toOrdinal($pivot);
+
+        if ($rule === null) {
+            return $this->occurrenceIf($anchor, $length, static fn (Occurrence $occurrence): bool => $occurrence->end->compare($pivot) < 0);
+        }
+
+        if ($rule->frequency === RecurrenceRule::MOON_PHASE) {
+            $end = $this->chronology->fromOrdinal($pivotOrdinal - $length);
+            $phases = $this->moonPhases->phasesBetween($this->chronology->fromOrdinal($pivotOrdinal - $this->searchLimit($rule)), $end);
+            foreach (array_reverse($phases) as $phase) {
+                if ($phase->moonId !== $rule->moonId || ! in_array($rule->phase, $phase->exactPhases, true) || $phase->ordinal < $this->chronology->toOrdinal($anchor)) {
+                    continue;
+                }
+                $occurrence = $this->buildOccurrence($phase->date, $length, 0);
+                if (! $this->pastUntil($occurrence->start, $rule) && $occurrence->end->compare($pivot) < 0) {
+                    return $occurrence;
+                }
+            }
+
+            return null;
+        }
+
+        $sequence = $this->firstSequenceAtOrAfter($anchor, $length, $rule, $pivot, true);
+        for (; $sequence >= 0; $sequence--) {
+            $candidate = $this->candidateAt($anchor, $rule, $sequence);
+            if ($candidate === null) {
+                continue;
+            }
+            if ($this->pastUntil($candidate, $rule)) {
+                continue;
+            }
+            $occurrence = $this->buildOccurrence($candidate, $length, $sequence);
+            if ($occurrence->end->compare($pivot) < 0) {
+                return $occurrence;
+            }
+        }
+
+        return null;
+    }
+
     private function makeOccurrence(CalendarDate $start, int $length, int $sequence, CalendarDate $from, CalendarDate $to): ?Occurrence
     {
         $end = $this->chronology->addDays($start, $length - 1);
@@ -190,6 +278,64 @@ final class OccurrenceEngine
         }
 
         return new Occurrence($start, $end, $sequence);
+    }
+
+    private function buildOccurrence(CalendarDate $start, int $length, int $sequence): Occurrence
+    {
+        return new Occurrence($start, $this->chronology->addDays($start, $length - 1), $sequence);
+    }
+
+    private function occurrenceIf(CalendarDate $start, int $length, callable $predicate): ?Occurrence
+    {
+        $occurrence = $this->buildOccurrence($start, $length, 0);
+
+        return $predicate($occurrence) ? $occurrence : null;
+    }
+
+    private function validate(CalendarDate $anchor, int $length, CalendarDate $pivot): void
+    {
+        if ($length < 1 || ! $this->chronology->isValid($anchor) || ! $this->chronology->isValid($pivot)) {
+            throw new InvalidArgumentException('Occurrence dates must be valid calendar dates.');
+        }
+    }
+
+    private function firstSequenceAtOrAfter(CalendarDate $anchor, int $length, RecurrenceRule $rule, CalendarDate $pivot, bool $past): int
+    {
+        $target = $this->chronology->fromOrdinal($this->chronology->toOrdinal($pivot) + ($past ? -$length : -($length - 1)));
+
+        return match ($rule->frequency) {
+            RecurrenceRule::DAILY => max(0, self::floorDiv($this->chronology->toOrdinal($target) - $this->chronology->toOrdinal($anchor), $rule->interval)),
+            RecurrenceRule::WEEKLY => max(0, self::floorDiv($this->chronology->toOrdinal($target) - $this->chronology->toOrdinal($anchor), $rule->interval * $this->chronology->definition()->weekdayCount())),
+            RecurrenceRule::MONTHLY => max(0, self::floorDiv($this->monthSerial($target) - $this->monthSerial($anchor), $rule->interval)),
+            RecurrenceRule::YEARLY => max(0, self::floorDiv($this->yearSerial($target->year) - $this->yearSerial($anchor->year), $rule->interval)),
+            default => 0,
+        };
+    }
+
+    private function candidateAt(CalendarDate $anchor, RecurrenceRule $rule, int $sequence): ?CalendarDate
+    {
+        return match ($rule->frequency) {
+            RecurrenceRule::DAILY => $this->chronology->addDays($anchor, $sequence * $rule->interval),
+            RecurrenceRule::WEEKLY => $this->chronology->addDays($anchor, $sequence * $rule->interval * $this->chronology->definition()->weekdayCount()),
+            RecurrenceRule::MONTHLY => $this->chronology->addMonths($anchor, $sequence * $rule->interval, $rule->invalidDate),
+            RecurrenceRule::YEARLY => $this->chronology->addYears($anchor, $sequence * $rule->interval, $rule->invalidDate),
+            default => null,
+        };
+    }
+
+    private function searchLimit(RecurrenceRule $rule): int
+    {
+        if ($rule->frequency !== RecurrenceRule::MOON_PHASE) {
+            return 0;
+        }
+
+        foreach ($this->chronology->definition()->moons as $moon) {
+            if ((int) ($moon['id'] ?? 0) === $rule->moonId) {
+                return max(2, (int) ceil(((float) ($moon['fullmoon'] ?? 1)) * 2));
+            }
+        }
+
+        return 1000;
     }
 
     private function pastUntil(CalendarDate $date, RecurrenceRule $rule): bool
@@ -220,5 +366,14 @@ final class OccurrenceEngine
         }
 
         return -intdiv(-$numerator, $denominator);
+    }
+
+    private static function floorDiv(int $numerator, int $denominator): int
+    {
+        if ($numerator >= 0) {
+            return intdiv($numerator, $denominator);
+        }
+
+        return -intdiv(-$numerator + $denominator - 1, $denominator);
     }
 }

--- a/app/Services/Calendars/OccurrenceEngine.php
+++ b/app/Services/Calendars/OccurrenceEngine.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace App\Services\Calendars;
+
+use App\ValueObjects\Calendars\CalendarDate;
+use App\ValueObjects\Calendars\Occurrence;
+use App\ValueObjects\Calendars\RecurrenceRule;
+use InvalidArgumentException;
+
+final class OccurrenceEngine
+{
+    public function __construct(private readonly CalendarChronology $chronology) {}
+
+    /**
+     * Generate occurrences intersecting an inclusive date window.
+     *
+     * @return list<Occurrence>
+     */
+    public function occurrences(
+        CalendarDate $anchor,
+        int $length,
+        ?RecurrenceRule $rule,
+        CalendarDate $from,
+        CalendarDate $to,
+    ): array {
+        if ($length < 1 || $from->compare($to) > 0) {
+            throw new InvalidArgumentException('Invalid occurrence range.');
+        }
+        if (! $this->chronology->isValid($anchor)
+            || ! $this->chronology->isValid($from)
+            || ! $this->chronology->isValid($to)) {
+            throw new InvalidArgumentException('Occurrence dates must be valid calendar dates.');
+        }
+
+        if ($rule === null) {
+            $occurrence = $this->makeOccurrence($anchor, $length, 0, $from, $to);
+
+            return $occurrence === null ? [] : [$occurrence];
+        }
+
+        return match ($rule->frequency) {
+            RecurrenceRule::DAILY, RecurrenceRule::WEEKLY => $this->fixedDayOccurrences($anchor, $length, $rule, $from, $to),
+            RecurrenceRule::MONTHLY => $this->monthlyOccurrences($anchor, $length, $rule, $from, $to),
+            RecurrenceRule::YEARLY => $this->yearlyOccurrences($anchor, $length, $rule, $from, $to),
+            RecurrenceRule::MOON_PHASE => $this->moonOccurrences($anchor, $length, $rule, $from, $to),
+            default => throw new InvalidArgumentException('Unsupported recurrence frequency.'),
+        };
+    }
+
+    /** @return list<Occurrence> */
+    private function fixedDayOccurrences(CalendarDate $anchor, int $length, RecurrenceRule $rule, CalendarDate $from, CalendarDate $to): array
+    {
+        $step = $rule->frequency === RecurrenceRule::WEEKLY
+            ? $rule->interval * $this->chronology->definition()->weekdayCount()
+            : $rule->interval;
+        $anchorOrdinal = $this->chronology->toOrdinal($anchor);
+        $firstOrdinal = $this->chronology->toOrdinal($from) - ($length - 1);
+        $sequence = max(0, self::ceilDiv($firstOrdinal - $anchorOrdinal, $step));
+        $occurrences = [];
+
+        while (true) {
+            $candidate = $this->chronology->fromOrdinal($anchorOrdinal + ($sequence * $step));
+            if ($this->pastUntil($candidate, $rule) || $candidate->compare($to) > 0) {
+                break;
+            }
+            $occurrence = $this->makeOccurrence($candidate, $length, $sequence, $from, $to);
+            if ($occurrence !== null) {
+                $occurrences[] = $occurrence;
+            }
+            $sequence++;
+        }
+
+        return $occurrences;
+    }
+
+    /** @return list<Occurrence> */
+    private function monthlyOccurrences(CalendarDate $anchor, int $length, RecurrenceRule $rule, CalendarDate $from, CalendarDate $to): array
+    {
+        $targetSerial = $this->chronology->toOrdinal($from);
+        $monthDistance = $this->monthSerial($from) - $this->monthSerial($anchor);
+        $sequence = max(0, self::ceilDiv($monthDistance, $rule->interval));
+        if ($this->chronology->toOrdinal($anchor) + $length - 1 >= $targetSerial) {
+            $sequence = 0;
+        }
+        $occurrences = [];
+
+        while (true) {
+            if ($this->monthSerial($anchor) + ($sequence * $rule->interval) > $this->monthSerial($to)) {
+                break;
+            }
+            $candidate = $this->chronology->addMonths($anchor, $sequence * $rule->interval, $rule->invalidDate);
+            if ($candidate === null) {
+                $sequence++;
+
+                continue;
+            }
+            if ($this->pastUntil($candidate, $rule) || $candidate->compare($to) > 0) {
+                break;
+            }
+            if ($this->chronology->toOrdinal($candidate) + $length - 1 >= $targetSerial) {
+                $occurrence = $this->makeOccurrence($candidate, $length, $sequence, $from, $to);
+                if ($occurrence !== null) {
+                    $occurrences[] = $occurrence;
+                }
+            }
+            $sequence++;
+        }
+
+        return $occurrences;
+    }
+
+    /** @return list<Occurrence> */
+    private function yearlyOccurrences(CalendarDate $anchor, int $length, RecurrenceRule $rule, CalendarDate $from, CalendarDate $to): array
+    {
+        $yearDistance = $this->yearSerial($from->year) - $this->yearSerial($anchor->year);
+        $sequence = max(0, self::ceilDiv($yearDistance, $rule->interval));
+        if ($this->chronology->toOrdinal($anchor) + $length - 1 >= $this->chronology->toOrdinal($from)) {
+            $sequence = 0;
+        }
+        $occurrences = [];
+
+        while (true) {
+            if ($this->yearSerial($anchor->year) + ($sequence * $rule->interval) > $this->yearSerial($to->year)) {
+                break;
+            }
+            $candidate = $this->chronology->addYears($anchor, $sequence * $rule->interval, $rule->invalidDate);
+            if ($candidate === null) {
+                $sequence++;
+
+                continue;
+            }
+            if ($this->pastUntil($candidate, $rule) || $candidate->compare($to) > 0) {
+                break;
+            }
+            $occurrence = $this->makeOccurrence($candidate, $length, $sequence, $from, $to);
+            if ($occurrence !== null) {
+                $occurrences[] = $occurrence;
+            }
+            $sequence++;
+        }
+
+        return $occurrences;
+    }
+
+    /** @return list<Occurrence> */
+    private function moonOccurrences(CalendarDate $anchor, int $length, RecurrenceRule $rule, CalendarDate $from, CalendarDate $to): array
+    {
+        $moon = collect($this->chronology->definition()->moons)->firstWhere('id', $rule->moonId);
+        if (! is_array($moon) || (float) ($moon['fullmoon'] ?? 0) <= 0) {
+            throw new InvalidArgumentException("Unknown moon: {$rule->moonId}");
+        }
+
+        $cycle = (float) $moon['fullmoon'];
+        $phaseOffset = $rule->phase === 'new' ? $cycle / 2 : 0;
+        $start = $this->chronology->toOrdinal($from) - ($length - 1);
+        $end = $this->chronology->toOrdinal($to);
+        $anchorOrdinal = $this->chronology->toOrdinal($anchor);
+        $firstCycle = (int) floor(($start - (float) ($moon['offset'] ?? 0) - $phaseOffset) / $cycle) - 1;
+        $lastCycle = (int) ceil(($end - (float) ($moon['offset'] ?? 0) - $phaseOffset) / $cycle) + 1;
+        $occurrences = [];
+        $sequence = 0;
+        $seen = [];
+
+        for ($cycleNumber = $firstCycle; $cycleNumber <= $lastCycle; $cycleNumber++) {
+            $ordinal = (int) floor((float) ($moon['offset'] ?? 0) + $phaseOffset + ($cycleNumber * $cycle));
+            if ($ordinal < $anchorOrdinal || isset($seen[$ordinal])) {
+                continue;
+            }
+            $seen[$ordinal] = true;
+            $candidate = $this->chronology->fromOrdinal($ordinal);
+            if ($this->pastUntil($candidate, $rule) || $candidate->compare($to) > 0) {
+                continue;
+            }
+            $occurrence = $this->makeOccurrence($candidate, $length, $sequence++, $from, $to);
+            if ($occurrence !== null) {
+                $occurrences[] = $occurrence;
+            }
+        }
+
+        usort($occurrences, static fn (Occurrence $a, Occurrence $b): int => $a->start->compare($b->start));
+
+        return $occurrences;
+    }
+
+    private function makeOccurrence(CalendarDate $start, int $length, int $sequence, CalendarDate $from, CalendarDate $to): ?Occurrence
+    {
+        $end = $this->chronology->addDays($start, $length - 1);
+        if ($end->compare($from) < 0 || $start->compare($to) > 0) {
+            return null;
+        }
+
+        return new Occurrence($start, $end, $sequence);
+    }
+
+    private function pastUntil(CalendarDate $date, RecurrenceRule $rule): bool
+    {
+        return $rule->untilYear !== null && $date->year > $rule->untilYear;
+    }
+
+    private function monthSerial(CalendarDate $date): int
+    {
+        $yearSerial = $this->yearSerial($date->year);
+
+        return $yearSerial * $this->chronology->definition()->monthCount() + $date->month - 1;
+    }
+
+    private function yearSerial(int $year): int
+    {
+        if ($this->chronology->definition()->hasYearZero) {
+            return $year;
+        }
+
+        return $year > 0 ? $year - 1 : $year;
+    }
+
+    private static function ceilDiv(int $numerator, int $denominator): int
+    {
+        if ($numerator >= 0) {
+            return intdiv($numerator + $denominator - 1, $denominator);
+        }
+
+        return -intdiv(-$numerator, $denominator);
+    }
+}

--- a/app/Services/Calendars/RecurrenceOptionsService.php
+++ b/app/Services/Calendars/RecurrenceOptionsService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Services\Calendars;
+
+use App\Models\Calendar;
+
+final class RecurrenceOptionsService
+{
+    /** @return array<string, string|array<string, string>> */
+    public function forSelect(Calendar $calendar): array
+    {
+        $options = $this->baseOptions();
+        $unnamed = 0;
+
+        foreach ($calendar->moons() as $moon) {
+            $name = (string) ($moon['name'] ?? '');
+            if ($name === '') {
+                $unnamed++;
+                $name = __('calendars.options.events.recurring_periodicity.unnamed_moon', ['number' => $unnamed]);
+            }
+
+            $options[$name] = [
+                $moon['id'] . '_f' => __('calendars.options.events.recurring_periodicity.fullmoon'),
+                $moon['id'] . '_n' => __('calendars.options.events.recurring_periodicity.newmoon'),
+            ];
+        }
+
+        return $options;
+    }
+
+    /** @return array<string, string> */
+    public function forApi(Calendar $calendar): array
+    {
+        $options = $this->baseOptions();
+
+        foreach ($calendar->moons() as $moon) {
+            $name = (string) ($moon['name'] ?? '');
+            $options[$moon['id'] . '_f'] = __('calendars.options.events.recurring_periodicity.fullmoon_name', ['moon' => $name]);
+            $options[$moon['id'] . '_n'] = __('calendars.options.events.recurring_periodicity.newmoon_name', ['moon' => $name]);
+        }
+
+        return $options;
+    }
+
+    /** @return array<string, string> */
+    private function baseOptions(): array
+    {
+        return [
+            '' => __('calendars.options.events.recurring_periodicity.none'),
+            'month' => __('calendars.options.events.recurring_periodicity.month'),
+            'year' => __('calendars.options.events.recurring_periodicity.year'),
+        ];
+    }
+}

--- a/app/Services/Calendars/ReminderService.php
+++ b/app/Services/Calendars/ReminderService.php
@@ -6,12 +6,20 @@ use App\Models\Calendar;
 use App\Models\Entity;
 use App\Models\Post;
 use App\Models\Reminder;
+use App\ValueObjects\Calendars\CalendarDate;
+use App\ValueObjects\Calendars\ReminderOccurrence;
+use App\ValueObjects\Calendars\ReminderWindow;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 
 class ReminderService
 {
     protected Calendar $calendar;
+
+    public function __construct(
+        private readonly LegacyRecurrenceAdapter $adapter,
+    ) {}
 
     public function calendar(Calendar $calendar): self
     {
@@ -20,151 +28,102 @@ class ReminderService
         return $this;
     }
 
-    /**
-     * Look at events to calculate the most upcoming events for the calendar
-     * dashboard widget.
-     */
-    public function upcoming(int $needle = 10): Collection
+    public function around(int $limit = 5): ReminderWindow
+    {
+        $today = new CalendarDate(
+            $this->calendar->currentYear(),
+            $this->calendar->currentMonth(),
+            $this->calendar->currentDay(),
+        );
+        $chronology = $this->calendar->chronology();
+        $engine = new OccurrenceEngine($chronology, new MoonPhaseCalculator($chronology));
+        $past = collect();
+        $upcoming = collect();
+
+        foreach ($this->reminders() as $reminder) {
+            $reminder->setRelation('calendar', $this->calendar);
+
+            try {
+                $anchor = new CalendarDate((int) $reminder->year, (int) $reminder->month, (int) $reminder->day);
+                if (! $chronology->isValid($anchor)) {
+                    continue;
+                }
+                $rule = $this->adapter->fromReminder($reminder);
+                $next = $engine->nextOrActiveOccurrence($anchor, (int) $reminder->length, $rule, $today);
+                $previous = $engine->previousOccurrence($anchor, (int) $reminder->length, $rule, $today);
+
+                if ($previous !== null) {
+                    $past->push(new ReminderOccurrence(
+                        $reminder,
+                        $previous,
+                        $chronology->toOrdinal($today) - $chronology->toOrdinal($previous->end),
+                        'past',
+                    ));
+                }
+                if ($next !== null) {
+                    $state = $next->start->compare($today) <= 0 && $next->end->compare($today) >= 0
+                        ? 'active'
+                        : 'upcoming';
+                    $upcoming->push(new ReminderOccurrence(
+                        $reminder,
+                        $next,
+                        $state === 'active' ? 0 : $chronology->toOrdinal($next->start) - $chronology->toOrdinal($today),
+                        $state,
+                    ));
+                }
+            } catch (InvalidArgumentException) {
+                // Invalid historical reminder dates should not prevent the widget from rendering.
+            }
+        }
+
+        $past = $past->sort(static function (ReminderOccurrence $a, ReminderOccurrence $b) use ($chronology): int {
+            return $chronology->toOrdinal($b->occurrence->end) <=> $chronology->toOrdinal($a->occurrence->end)
+                ?: $b->reminder->id <=> $a->reminder->id;
+        })->take(max(0, $limit))->values();
+        $upcoming = $upcoming->sort(static function (ReminderOccurrence $a, ReminderOccurrence $b) use ($chronology): int {
+            return (int) $b->isActive() <=> (int) $a->isActive()
+                ?: $chronology->toOrdinal($a->occurrence->start) <=> $chronology->toOrdinal($b->occurrence->start)
+                ?: $a->reminder->id <=> $b->reminder->id;
+        })->take(max(0, $limit))->values();
+
+        return new ReminderWindow($past, $upcoming);
+    }
+
+    /** @return Collection<int, ReminderOccurrence> */
+    public function upcoming(int $limit = 5): Collection
+    {
+        return $this->around($limit)->upcoming;
+    }
+
+    /** @return Collection<int, ReminderOccurrence> */
+    public function past(int $limit = 5): Collection
+    {
+        return $this->around($limit)->past;
+    }
+
+    /** @return Collection<int, Reminder> */
+    private function reminders(): Collection
     {
         // @phpstan-ignore-next-line
-        $reminders = $this->calendar->calendarEvents()
-            ->with(['remindable'])
+        return $this->calendar->calendarEvents()
+            ->with([
+                'remindable' => function ($morphTo): void {
+                    $morphTo->morphWith([
+                        Entity::class => [],
+                        Post::class => ['entity'],
+                    ]);
+                },
+            ])
             ->whereHasMorph(
                 'remindable',
                 [Entity::class, Post::class],
-                function (Builder $query, string $type) {
+                function (Builder $query, string $type): void {
                     if ($type === Post::class) {
                         $query->whereHas('entity');
                     }
-                })
-            ->where(function ($primary) {
-                $primary->where(function ($sub) {
-                    $sub->where(function ($recurring) {
-                        $recurring
-                            ->where('is_recurring', true)
-                            ->whereIn('recurring_periodicity', ['year', 'month'])
-                            ->where(function ($recurringuntil) {
-                                $recurringuntil
-                                    ->whereNull('recurring_until')
-                                    // Events that end in the future are fine, they could be reoccurring on this month
-                                    ->orWhere('recurring_until', '>=', $this->calendar->currentYear());
-                            });
-                    });
-                })
-                    ->orWhere(function ($ondate) {
-                        // Not recurring
-                        $ondate
-                            ->where('is_recurring', false)
-                            ->where(function ($date) {
-                                // An event that happens before this year
-                                $date
-                                    ->where('year', '>', $this->calendar->currentYear())
-                                    ->orWhere(function ($subdate) {
-                                        // An event that happens this year but after this month
-                                        $subdate
-                                            ->where('year', $this->calendar->currentYear())
-                                            ->where('month', '>', $this->calendar->currentMonth());
-                                    })
-                                    ->orWhere(function ($subdate) {
-                                        // An event that happens this year after this year
-                                        $subdate
-                                            ->where('year', $this->calendar->currentYear())
-                                            ->where('month', $this->calendar->currentMonth())
-                                            ->where('day', '>=', $this->calendar->currentDay());
-                                    });
-                            });
-                    });
-            })
-            // Skip events that were on months which no longer exist
-            ->where('month', '<=', count($this->calendar->months()))
-            ->orderBy('year', 'asc')
-            ->orderBy('month', 'asc')
-            ->orderBy('day', 'asc')
-            ->take($needle)
+                },
+            )
+            ->orderBy('id')
             ->get();
-
-        // Order the past events in descending date to get the closest ones to the current date first
-        return $reminders->sortBy(function (Reminder $reminder) {
-            return $reminder
-                ->setRelation('calendar', $this->calendar)
-                ->nextUpcomingOccurrence(
-                    $this->calendar->currentYear(),
-                    $this->calendar->currentMonth(),
-                    $this->calendar->currentDay(),
-                    $this->calendar->months(),
-                    $this->calendar->daysInYear()
-                );
-        });
-    }
-
-    /**
-     * Look at events to calculate the most recently occurring events for the calendar
-     * dashboard widget.
-     */
-    public function past(int $needle = 10): Collection
-    {
-        // @phpstan-ignore-next-line
-        $reminders = $this->calendar->calendarEvents()
-            ->with(['remindable'])
-            ->whereHas('remindable')
-            ->where(function ($primary) {
-                $primary->where(function ($sub) {
-                    $sub->where(function ($recurring) {
-                        $recurring
-                            ->where('is_recurring', true)
-                            ->whereIn('recurring_periodicity', ['year', 'month'])
-                            ->where(function ($recurringuntil) {
-                                $recurringuntil
-                                    ->whereNull('recurring_until')
-                                    // Events that end in the future are fine, they could be reoccurring on this month
-                                    ->orWhere('recurring_until', '>=', $this->calendar->currentYear());
-                            })
-                            ->where('year', '<=', $this->calendar->currentYear());
-                    });
-                })
-                    ->orWhere(function ($ondate) {
-                        // Not recurring
-                        $ondate
-                            ->where('is_recurring', false)
-                            ->where(function ($date) {
-                                // An event that happens before this year
-                                $date
-                                    ->where('year', '<', $this->calendar->currentYear())
-                                    ->orWhere(function ($subdate) {
-                                        // An event that happens this year but before this month
-                                        $subdate
-                                            ->where('year', $this->calendar->currentYear())
-                                            ->where('month', '<', $this->calendar->currentMonth());
-                                    })
-                                    ->orWhere(function ($subdate) {
-                                        // An event that happens this year but before this day
-                                        $subdate
-                                            ->where('year', $this->calendar->currentYear())
-                                            ->where('month', $this->calendar->currentMonth())
-                                            ->where('day', '<', $this->calendar->currentDay());
-                                    });
-                            });
-                    });
-            })
-            // Skip events that were on months which no longer exist
-            ->where('month', '<=', count($this->calendar->months()))
-            ->orderBy('year', 'desc')
-            ->orderBy('month', 'desc')
-            ->orderBy('day', 'desc')
-            ->take($needle)
-            ->get();
-
-        // Order the past events in descending date to get the closest ones to the current date first
-        return $reminders->sortBy(function (Reminder $reminder) {
-            return $reminder
-                ->setRelation('calendar', $this->calendar)
-                ->mostRecentOccurrence(
-                    $this->calendar->currentYear(),
-                    $this->calendar->currentMonth(),
-                    $this->calendar->currentDay(),
-                    $this->calendar->months(),
-                    $this->calendar->daysInYear()
-                );
-        });
     }
 }

--- a/app/ValueObjects/Calendars/CalendarDate.php
+++ b/app/ValueObjects/Calendars/CalendarDate.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+use InvalidArgumentException;
+use JsonSerializable;
+use Stringable;
+
+final readonly class CalendarDate implements JsonSerializable, Stringable
+{
+    public function __construct(
+        public int $year,
+        public int $month,
+        public int $day,
+    ) {
+        if ($this->month < 1 || $this->day < 1) {
+            throw new InvalidArgumentException('Calendar dates must use positive months and days.');
+        }
+    }
+
+    public static function fromString(string $date): self
+    {
+        if (! preg_match('/^(-?\d+)-(\d+)-(\d+)$/', $date, $parts)) {
+            throw new InvalidArgumentException("Invalid calendar date: {$date}");
+        }
+
+        return new self((int) $parts[1], (int) $parts[2], (int) $parts[3]);
+    }
+
+    /** @param array{0: int|string, 1: int|string, 2: int|string} $date */
+    public static function fromArray(array $date): self
+    {
+        return new self((int) $date[0], (int) $date[1], (int) $date[2]);
+    }
+
+    public function key(): string
+    {
+        return (string) $this;
+    }
+
+    /** @return array{year: int, month: int, day: int, key: string} */
+    public function toArray(): array
+    {
+        return [
+            'year' => $this->year,
+            'month' => $this->month,
+            'day' => $this->day,
+            'key' => $this->key(),
+        ];
+    }
+
+    public function compare(self $other): int
+    {
+        return $this->year <=> $other->year
+            ?: $this->month <=> $other->month
+            ?: $this->day <=> $other->day;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function __toString(): string
+    {
+        return "{$this->year}-{$this->month}-{$this->day}";
+    }
+}

--- a/app/ValueObjects/Calendars/CalendarDefinition.php
+++ b/app/ValueObjects/Calendars/CalendarDefinition.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+use App\Models\Calendar;
+use InvalidArgumentException;
+
+final readonly class CalendarDefinition
+{
+    /** @param array<int, array{name: string, length: int, type?: string, alias?: string}> $months */
+    /** @param array<int, string|array{name?: string}> $weekdays */
+    /** @param array<int, LeapRule> $leapRules */
+    /** @param array<int, array{id?: int, name?: string, fullmoon: float|int, offset?: float|int, colour?: string}> $moons */
+    public function __construct(
+        public array $months,
+        public array $weekdays = [],
+        public array $leapRules = [],
+        public array $moons = [],
+        public bool $hasYearZero = true,
+        public int $startOffset = 0,
+    ) {
+        if ($this->months === []) {
+            throw new InvalidArgumentException('A calendar must define at least one month.');
+        }
+    }
+
+    public static function fromCalendar(Calendar $calendar): self
+    {
+        $rules = [];
+        if ((bool) $calendar->has_leap_year) {
+            $rules[] = new LeapRule(
+                (int) $calendar->leap_year_amount,
+                (int) $calendar->leap_year_month,
+                max(1, (int) $calendar->leap_year_offset),
+                (int) $calendar->leap_year_start,
+            );
+        }
+
+        return new self(
+            self::normalizeMonths($calendar->months()),
+            $calendar->weekdays(),
+            $rules,
+            $calendar->moons(),
+            $calendar->hasYearZero(),
+            (int) $calendar->start_offset,
+        );
+    }
+
+    /** @param array<string, mixed> $config */
+    public static function fromArray(array $config): self
+    {
+        $rules = array_map(
+            static fn (array $rule): LeapRule => new LeapRule(
+                (int) ($rule['amount'] ?? 0),
+                (int) ($rule['month'] ?? 1),
+                (int) ($rule['interval'] ?? 1),
+                (int) ($rule['start'] ?? 0),
+            ),
+            $config['leap_rules'] ?? [],
+        );
+
+        return new self(
+            self::normalizeMonths($config['months'] ?? []),
+            $config['weekdays'] ?? [],
+            $rules,
+            $config['moons'] ?? [],
+            ! (bool) ($config['skip_year_zero'] ?? false),
+            (int) ($config['start_offset'] ?? 0),
+        );
+    }
+
+    public function monthCount(): int
+    {
+        return count($this->months);
+    }
+
+    /** @return array{name: string, length: int, type: string, alias: string} */
+    public function month(int $month): array
+    {
+        if ($month < 1 || $month > $this->monthCount()) {
+            throw new InvalidArgumentException("Unknown calendar month: {$month}");
+        }
+
+        return $this->months[$month - 1];
+    }
+
+    public function weekdayCount(): int
+    {
+        return max(1, count($this->weekdays));
+    }
+
+    public function isIntercalary(int $month): bool
+    {
+        return ($this->month($month)['type'] ?? 'standard') === 'intercalary';
+    }
+
+    private static function normalizeMonths(mixed $months): array
+    {
+        if (! is_array($months)) {
+            throw new InvalidArgumentException('Calendar months must be an array.');
+        }
+
+        return array_values(array_map(
+            static function (mixed $month): array {
+                if (! is_array($month) || (int) ($month['length'] ?? 0) < 1) {
+                    throw new InvalidArgumentException('Each calendar month must have a positive length.');
+                }
+
+                return [
+                    'name' => (string) ($month['name'] ?? ''),
+                    'length' => (int) $month['length'],
+                    'type' => (string) ($month['type'] ?? 'standard'),
+                    'alias' => (string) ($month['alias'] ?? ''),
+                ];
+            },
+            $months,
+        ));
+    }
+}

--- a/app/ValueObjects/Calendars/CalendarWidgetState.php
+++ b/app/ValueObjects/Calendars/CalendarWidgetState.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+use App\Models\CalendarWeather;
+use Illuminate\Support\Collection;
+
+final readonly class CalendarWidgetState
+{
+    /** @param Collection<int, ReminderOccurrence> $previousEvents */
+    /** @param Collection<int, ReminderOccurrence> $upcomingEvents */
+    /** @param list<MoonState> $currentMoons */
+    public function __construct(
+        public Collection $previousEvents,
+        public Collection $upcomingEvents,
+        public array $currentMoons,
+        public ?string $currentWeekdayName,
+        public ?CalendarWeather $weather,
+    ) {}
+}

--- a/app/ValueObjects/Calendars/LeapRule.php
+++ b/app/ValueObjects/Calendars/LeapRule.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+use InvalidArgumentException;
+
+final readonly class LeapRule
+{
+    public function __construct(
+        public int $amount,
+        public int $month,
+        public int $interval,
+        public int $startYear,
+    ) {
+        if ($this->amount < 0 || $this->month < 1 || $this->interval < 1) {
+            throw new InvalidArgumentException('Invalid calendar leap rule.');
+        }
+    }
+
+    public function appliesTo(int $year): bool
+    {
+        return $year >= $this->startYear
+            && ($year - $this->startYear) % $this->interval === 0;
+    }
+}

--- a/app/ValueObjects/Calendars/MoonPhaseOccurrence.php
+++ b/app/ValueObjects/Calendars/MoonPhaseOccurrence.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+final readonly class MoonPhaseOccurrence
+{
+    /** @param list<string> $exactPhases */
+    public function __construct(
+        public int $moonId,
+        public string $name,
+        public string $colour,
+        public string $phase,
+        public CalendarDate $date,
+        public int $ordinal,
+        public array $exactPhases = [],
+    ) {}
+}

--- a/app/ValueObjects/Calendars/MoonState.php
+++ b/app/ValueObjects/Calendars/MoonState.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+final readonly class MoonState
+{
+    /** @param list<string> $exactPhases */
+    public function __construct(
+        public int $moonId,
+        public string $name,
+        public string $colour,
+        public string $phase,
+        public CalendarDate $phaseDate,
+        public int $daysSincePhase,
+        public array $exactPhases = [],
+    ) {}
+
+    public function isExact(): bool
+    {
+        return $this->daysSincePhase === 0;
+    }
+}

--- a/app/ValueObjects/Calendars/Occurrence.php
+++ b/app/ValueObjects/Calendars/Occurrence.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+use JsonSerializable;
+
+final readonly class Occurrence implements JsonSerializable
+{
+    public function __construct(
+        public CalendarDate $start,
+        public CalendarDate $end,
+        public int $sequence,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'start' => $this->start,
+            'end' => $this->end,
+            'sequence' => $this->sequence,
+        ];
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/app/ValueObjects/Calendars/RecurrenceRule.php
+++ b/app/ValueObjects/Calendars/RecurrenceRule.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+use InvalidArgumentException;
+use JsonSerializable;
+
+final readonly class RecurrenceRule implements JsonSerializable
+{
+    public const DAILY = 'day';
+
+    public const WEEKLY = 'week';
+
+    public const MONTHLY = 'month';
+
+    public const YEARLY = 'year';
+
+    public const MOON_PHASE = 'moon_phase';
+
+    public function __construct(
+        public string $frequency,
+        public int $interval = 1,
+        public ?int $untilYear = null,
+        public ?int $moonId = null,
+        public ?string $phase = null,
+        public string $invalidDate = 'skip',
+    ) {
+        if ($this->interval < 1 || ! in_array($this->frequency, [
+            self::DAILY,
+            self::WEEKLY,
+            self::MONTHLY,
+            self::YEARLY,
+            self::MOON_PHASE,
+        ], true)) {
+            throw new InvalidArgumentException('Invalid recurrence rule.');
+        }
+
+        if (! in_array($this->invalidDate, ['skip', 'clamp'], true)) {
+            throw new InvalidArgumentException('Invalid recurrence date policy.');
+        }
+
+        if ($this->frequency === self::MOON_PHASE && ($this->moonId === null || $this->phase === null)) {
+            throw new InvalidArgumentException('Moon recurrence requires a moon and phase.');
+        }
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'version' => 1,
+            'frequency' => $this->frequency,
+            'interval' => $this->interval,
+            'until_year' => $this->untilYear,
+            'moon_id' => $this->moonId,
+            'phase' => $this->phase,
+            'invalid_date' => $this->invalidDate,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/app/ValueObjects/Calendars/ReminderOccurrence.php
+++ b/app/ValueObjects/Calendars/ReminderOccurrence.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+use App\Models\Reminder;
+
+final readonly class ReminderOccurrence
+{
+    public function __construct(
+        public Reminder $reminder,
+        public Occurrence $occurrence,
+        public int $distance,
+        public string $state,
+    ) {}
+
+    public function isActive(): bool
+    {
+        return $this->state === 'active';
+    }
+}

--- a/app/ValueObjects/Calendars/ReminderWindow.php
+++ b/app/ValueObjects/Calendars/ReminderWindow.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\ValueObjects\Calendars;
+
+use Illuminate\Support\Collection;
+
+final readonly class ReminderWindow
+{
+    /** @param Collection<int, ReminderOccurrence> $past */
+    /** @param Collection<int, ReminderOccurrence> $upcoming */
+    public function __construct(
+        public Collection $past,
+        public Collection $upcoming,
+    ) {}
+}

--- a/lang/en/calendars.php
+++ b/lang/en/calendars.php
@@ -205,6 +205,7 @@ return [
     'show'          => [
         'missing_details'       => 'This calendar couldn\'t be displayed. Calendars need at least 2 months and 2 weekdays to render properly.',
         'moon_1first_quarter'   => ':moon first quarter',
+        'moon_age'              => ':phase (:count day ago)|:phase (:count days ago)',
         'moon_full'             => ':moon full moon',
         'moon_last_quarter'     => ':moon last quarter',
         'moon_new'              => ':moon new moon',

--- a/lang/en/dashboard.php
+++ b/lang/en/dashboard.php
@@ -73,12 +73,15 @@ return [
     'title'         => 'Dashboard',
     'widgets'       => [
         'advanced_options_boosted'  => 'Enable more options like showing pins with a :boosted_campaign.',
-        'calendar'                  => [
-            'actions'           => [
-                'next'      => 'Change date to next day',
-                'previous'  => 'Change date to previous day',
-            ],
-            'previous_events'   => 'Previous',
+            'calendar'                  => [
+                'actions'           => [
+                    'next'      => 'Change date to next day',
+                    'previous'  => 'Change date to previous day',
+                ],
+                'days_ago'          => ':count day ago|:count days ago',
+                'happening_now'     => 'Happening now',
+                'in_days'           => 'in :count day|in :count days',
+                'previous_events'   => 'Previous',
             'upcoming_events'   => 'Upcoming',
         ],
         'campaign'                  => [

--- a/resources/views/calendars/reminders/_subform.blade.php
+++ b/resources/views/calendars/reminders/_subform.blade.php
@@ -50,7 +50,7 @@
     <x-forms.field
         field="recurring"
         :label="__('calendars.fields.is_recurring')">
-        <x-forms.select name="recurring_periodicity" :options="isset($calendar) ? $calendar->recurringOptions() : []" :selected="$reminder->recurring_periodicity ?? null" class="w-full reminder-periodicity" />
+        <x-forms.select name="recurring_periodicity" :options="isset($calendar) ? app(\App\Services\Calendars\RecurrenceOptionsService::class)->forSelect($calendar) : []" :selected="$reminder->recurring_periodicity ?? null" class="w-full reminder-periodicity" />
     </x-forms.field>
 
     <x-forms.field field="recurring-until" :hidden="!isset($reminder) || !$reminder->is_recurring" :label="__('calendars.fields.recurring_until')"  id="add_event_recurring_until">
@@ -75,5 +75,4 @@
         </x-forms.field>
     @endif
 </x-grid>
-
 

--- a/resources/views/cruds/forms/_calendar.blade.php
+++ b/resources/views/cruds/forms/_calendar.blade.php
@@ -119,7 +119,7 @@ $opened = (isset($model) && $model->hasCalendar()) || !empty($oldCalendarID);
                     :label="__('calendars.fields.is_recurring')">
                     <x-forms.select
                         name="calendar_recurring_periodicity"
-                        :options="(!empty($model) && $model->hasCalendar() ? $model->calendarReminder()->calendar->recurringOptions(): (!empty($calendar) ? $calendar->recurringOptions() : []))"
+                        :options="(!empty($model) && $model->hasCalendar() ? app(\App\Services\Calendars\RecurrenceOptionsService::class)->forSelect($model->calendarReminder()->calendar): (!empty($calendar) ? app(\App\Services\Calendars\RecurrenceOptionsService::class)->forSelect($calendar) : []))"
                         :selected="$source->calendar_recurring_periodicity ?? $model->calendar_recurring_periodicity ?? null"
                         class="reminder-periodicity"
                         />

--- a/resources/views/dashboard/widgets/calendar/_reminder.blade.php
+++ b/resources/views/dashboard/widgets/calendar/_reminder.blade.php
@@ -1,10 +1,13 @@
-<?php /** @var \App\Models\Reminder $reminder */?>
 <?php
-if ($reminder->remindable instanceof \App\Models\Post && !$reminder->remindable->entity) {
+/** @var \App\ValueObjects\Calendars\ReminderOccurrence $reminderOccurrence */
+$reminder = $reminderOccurrence->reminder;
+$occurrence = $reminderOccurrence->occurrence;
+if ($reminder->remindable instanceof \App\Models\Post && ! $reminder->remindable->entity) {
     return;
 }
+$occurrenceDate = $calendar->niceDate((string) $occurrence->start);
 ?>
-<li data-ago="{{ isset($future) ? $reminder->inDays() : $reminder->daysAgo() }}" class="flex gap-2 justify-between overflow-hidden">
+<li data-ago="{{ $reminderOccurrence->distance }}" data-state="{{ $reminderOccurrence->state }}" class="flex gap-2 justify-between overflow-hidden">
     <div class="truncate">
         @if ($reminder->isPost())
             <x-entity-link :entity="$reminder->remindable->entity" :campaign="$campaign">
@@ -16,10 +19,12 @@ if ($reminder->remindable instanceof \App\Models\Post && !$reminder->remindable-
             </x-entity-link>
         @endif
         @if (config('app.debug'))
-            @if (isset($future))
-                <span class="text-xs text-neutral-content">({{ $reminder->date() }}, in {{ $reminder->inDays() }} days)</span>
+            @if ($reminderOccurrence->isActive())
+                <span class="text-xs text-neutral-content">({{ $occurrence->start->key() }}, {{ __('dashboard.widgets.calendar.happening_now') }})</span>
+            @elseif ($reminderOccurrence->state === 'upcoming')
+                <span class="text-xs text-neutral-content">({{ $occurrence->start->key() }}, {{ trans_choice('dashboard.widgets.calendar.in_days', $reminderOccurrence->distance, ['count' => $reminderOccurrence->distance]) }})</span>
             @else
-                <span class="text-xs text-neutral-content">({{ $reminder->date() }}, {{ $reminder->daysAgo() }} days ago)</span>
+                <span class="text-xs text-neutral-content">({{ $occurrence->start->key() }}, {{ trans_choice('dashboard.widgets.calendar.days_ago', $reminderOccurrence->distance, ['count' => $reminderOccurrence->distance]) }})</span>
             @endif
         @endif
     </div>
@@ -31,6 +36,6 @@ if ($reminder->remindable instanceof \App\Models\Post && !$reminder->remindable-
         @if ($reminder->is_recurring)
             <x-icon class="fa-regular fa-arrows-rotate" title="{{ __('calendars.fields.is_recurring') }}" tooltip />
         @endif
-        <x-icon class="fa-regular fa-calendar" title="{{ $reminder->readableDate() }}" tooltip />
+        <x-icon class="fa-regular fa-calendar" title="{{ $occurrenceDate }}" tooltip />
     </div>
 </li>

--- a/resources/views/dashboard/widgets/calendar/body.blade.php
+++ b/resources/views/dashboard/widgets/calendar/body.blade.php
@@ -1,54 +1,20 @@
-@inject ('reminderService', 'App\Services\Calendars\ReminderService')
 <?php
 /**
  * @var \App\Models\CampaignDashboardWidget $widget
  * @var \App\Models\Entity $entity
  * @var \App\Models\Calendar $calendar
- * @var \App\Models\EntityEvent $event
- * @var \App\Models\EntityEvent $reminder
- * @var \App\Models\EntityEvent $event
- * @var \App\Services\Calendars\ReminderService $reminderService
+ * @var \App\ValueObjects\Calendars\CalendarWidgetState $state
  */
 $entity = $widget->entity;
 if (empty($entity)) {
     return;
 }
 $calendar = $calendar ?? $entity->child;
-
-$upcomingEvents = $reminderService->calendar($calendar)->upcoming();
-$previousEvents = $reminderService->past();
-//$previousEvents = new \Illuminate\Support\Collection();
-
-// Get the current day's weather effect.
-$weather = $calendar->calendarWeather()
-    ->year($calendar->currentYear())
-    ->month($calendar->currentMonth())
-    ->where('day', $calendar->currentDay())
-    ->first();
-
-$daysService = new \App\Services\Calendars\DaysService();
-$totalDays = $daysService->calendar($calendar)
-    ->intercalary(true)
-    ->year($calendar->currentYear())
-    ->month($calendar->currentMonth())
-    ->daysToDate();
-
-$moonService = new \App\Services\Calendars\MoonService();
-$moonService->calendar($calendar);
-
-$moonService->build(
-    $totalDays,
-    $calendar->daysInYear()
-);
-$currentMoons = $moonService->get($calendar->currentDay());
-
-$weekdays = $calendar->weekdays();
-$weekdayCount = count($weekdays);
-$currentWeekdayName = null;
-if ($weekdayCount > 0) {
-    $weekdayIndex = (($totalDays + $calendar->start_offset + $calendar->currentDay() - 1) % $weekdayCount + $weekdayCount) % $weekdayCount;
-    $currentWeekdayName = $weekdays[$weekdayIndex] ?? null;
-}
+$upcomingEvents = $state->upcomingEvents;
+$previousEvents = $state->previousEvents;
+$currentMoons = $state->currentMoons;
+$currentWeekdayName = $state->currentWeekdayName;
+$weather = $state->weather;
 ?>
 <div class="flex flex-col gap-2">
 
@@ -71,11 +37,26 @@ if ($weekdayCount > 0) {
         @if (!empty($currentMoons))
             <div class="flex gap-1 moons">
                 @foreach ($currentMoons as $moon)
+                    @php
+                        $phaseKey = $moon->phase === 'first_quarter' ? '1first_quarter' : $moon->phase;
+                        $phaseLabel = __('calendars.show.moon_' . $phaseKey, ['moon' => $moon->name]);
+                        $moonTitle = $moon->isExact()
+                            ? $phaseLabel
+                            : trans_choice('calendars.show.moon_age', $moon->daysSincePhase, ['phase' => $phaseLabel, 'count' => $moon->daysSincePhase]);
+                        $moonClass = match ($moon->phase) {
+                            'full' => 'fa-regular fa-circle',
+                            'new' => 'fa-solid fa-circle',
+                            'last_quarter' => 'fa-solid fa-circle-half-stroke fa-flip-horizontal',
+                            'first_quarter' => 'fa-solid fa-circle-half-stroke',
+                            default => 'fa-regular fa-circle',
+                        };
+                    @endphp
                     <i
-                        class="{{ $moon['class'] }} text-{{ $moon['colour'] }}"
-                        data-id="{{ $moon['id'] }}"
+                        class="{{ $moonClass }}"
+                        style="color: {{ $moon->colour }}"
+                        data-id="{{ $moon->moonId }}"
                         data-toggle="tooltip"
-                        data-title="{{ __('calendars.show.moon_' . $moon['type'], ['moon' => $moon['name']]) }}"
+                        data-title="{{ $moonTitle }}"
                     ></i>
                 @endforeach
             </div>
@@ -109,8 +90,8 @@ if ($weekdayCount > 0) {
                     </a>
                 </div>
                 <ul class="style-none p-0">
-                    @foreach ($previousEvents->take(5) as $reminder)
-                        @includeWhen($reminder->remindable, 'dashboard.widgets.calendar._reminder')
+                    @foreach ($previousEvents as $reminderOccurrence)
+                        @includeWhen($reminderOccurrence->reminder->remindable, 'dashboard.widgets.calendar._reminder', ['reminderOccurrence' => $reminderOccurrence])
                     @endforeach
                 </ul>
             </div>
@@ -126,8 +107,8 @@ if ($weekdayCount > 0) {
                     </a>
                 </div>
                 <ul class="style-none p-0">
-                    @foreach ($upcomingEvents->take(5) as $reminder)
-                        @includeWhen($reminder->remindable, 'dashboard.widgets.calendar._reminder', ['future' => true])
+                    @foreach ($upcomingEvents as $reminderOccurrence)
+                        @includeWhen($reminderOccurrence->reminder->remindable, 'dashboard.widgets.calendar._reminder', ['reminderOccurrence' => $reminderOccurrence])
 
                     @endforeach
                 </ul>

--- a/tests/Feature/Services/Calendars/RecurrenceOptionsServiceTest.php
+++ b/tests/Feature/Services/Calendars/RecurrenceOptionsServiceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Calendar;
+use App\Services\Calendars\RecurrenceOptionsService;
+
+it('builds grouped select options from calendar moon definitions', function () {
+    $calendar = new Calendar([
+        'moons' => json_encode([
+            ['id' => 1, 'name' => 'Luna'],
+            ['id' => 2, 'name' => ''],
+        ]),
+    ]);
+
+    $options = new RecurrenceOptionsService()->forSelect($calendar);
+
+    expect($options['month'])->toBe(__('calendars.options.events.recurring_periodicity.month'))
+        ->and($options['Luna'])->toBe([
+            '1_f' => __('calendars.options.events.recurring_periodicity.fullmoon'),
+            '1_n' => __('calendars.options.events.recurring_periodicity.newmoon'),
+        ])
+        ->and($options[__('calendars.options.events.recurring_periodicity.unnamed_moon', ['number' => 1])])->toBe([
+            '2_f' => __('calendars.options.events.recurring_periodicity.fullmoon'),
+            '2_n' => __('calendars.options.events.recurring_periodicity.newmoon'),
+        ]);
+});
+
+it('builds flat API options without grouping moon names', function () {
+    $calendar = new Calendar([
+        'moons' => json_encode([
+            ['id' => 1, 'name' => 'Luna'],
+        ]),
+    ]);
+
+    $options = new RecurrenceOptionsService()->forApi($calendar);
+
+    expect($options)->toHaveKeys(['', 'month', 'year', '1_f', '1_n'])
+        ->and($options['1_f'])->toBe(__('calendars.options.events.recurring_periodicity.fullmoon_name', ['moon' => 'Luna']));
+});

--- a/tests/Feature/Services/Calendars/ReminderServiceTest.php
+++ b/tests/Feature/Services/Calendars/ReminderServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Models\Calendar;
+use App\Models\Event;
+use App\Models\Reminder;
+use App\Services\Calendars\ReminderService;
+
+function calendarReminder(Calendar $calendar, Event $event, array $attributes): Reminder
+{
+    $reminder = new Reminder($attributes + [
+        'calendar_id' => $calendar->id,
+        'length' => 1,
+        'visibility_id' => 1,
+    ]);
+    $reminder->remindable()->associate($event->entity);
+    $reminder->save();
+
+    return $reminder;
+}
+
+it('returns active recurring reminders in upcoming and concrete previous occurrences', function () {
+    $this->asUser()->withCampaign();
+    $calendar = Calendar::factory()->create([
+        'campaign_id' => 1,
+        'date' => '1-1-10',
+    ]);
+    $event = Event::factory()->create(['campaign_id' => 1]);
+    calendarReminder($calendar, $event, [
+        'year' => -1,
+        'month' => 12,
+        'day' => 9,
+        'length' => 2,
+        'is_recurring' => true,
+        'recurring_periodicity' => 'month',
+    ]);
+
+    $window = app(ReminderService::class)->calendar($calendar)->around(5);
+
+    expect($window->past)->toHaveCount(1)
+        ->and($window->past->first()->occurrence->start->key())->toBe('-1-12-9')
+        ->and($window->upcoming)->toHaveCount(1)
+        ->and($window->upcoming->first()->isActive())->toBeTrue();
+});
+
+it('sorts by actual occurrence instead of reminder anchor order', function () {
+    $this->asUser()->withCampaign();
+    $calendar = Calendar::factory()->create([
+        'campaign_id' => 1,
+        'date' => '1-1-1',
+    ]);
+    $firstEvent = Event::factory()->create(['campaign_id' => 1]);
+    $secondEvent = Event::factory()->create(['campaign_id' => 1]);
+
+    calendarReminder($calendar, $firstEvent, [
+        'year' => -20,
+        'month' => 1,
+        'day' => 20,
+        'is_recurring' => true,
+        'recurring_periodicity' => 'year',
+    ]);
+    $second = calendarReminder($calendar, $secondEvent, [
+        'year' => 1,
+        'month' => 1,
+        'day' => 3,
+        'is_recurring' => false,
+    ]);
+
+    $window = app(ReminderService::class)->calendar($calendar)->around(1);
+
+    expect($window->upcoming->first()->reminder->is($second))->toBeTrue();
+});

--- a/tests/Feature/Widgets/CalendarWidgetTest.php
+++ b/tests/Feature/Widgets/CalendarWidgetTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Enums\Widget;
+use App\Models\Calendar;
+use App\Models\CampaignDashboardWidget;
+
+function calendarWidget(): CampaignDashboardWidget
+{
+    $calendar = Calendar::factory()->create([
+        'campaign_id' => 1,
+        'date' => '1-1-3',
+        'moons' => json_encode([
+            ['id' => 1, 'name' => 'Luna', 'fullmoon' => 16, 'offset' => 0, 'colour' => 'grey'],
+        ]),
+    ]);
+
+    return CampaignDashboardWidget::create([
+        'campaign_id' => 1,
+        'entity_id' => $calendar->entity->id,
+        'widget' => Widget::Calendar,
+    ]);
+}
+
+it('renders semantic moon context and preserves the widget html contract', function () {
+    $this->asUser()->withCampaign();
+    $widget = calendarWidget();
+
+    $this->get('/w/test-campaign/dashboard/widgets/' . $widget->id . '/render')
+        ->assertSuccessful()
+        ->assertSee('data-id="1"', false)
+        ->assertSee('Luna full moon (2 days ago)', false)
+        ->assertSee('widget-calendar-switch', false);
+});
+
+it('prevents read-only users from changing the calendar widget date', function () {
+    $this->asUser()->withCampaign();
+    $widget = calendarWidget();
+    $date = $widget->entity->child->date;
+
+    $this->asPlayer()
+        ->post('/w/test-campaign/dashboard/widgets/' . $widget->id . '/add')
+        ->assertNotFound();
+
+    expect($widget->entity->child->fresh()->date)->toBe($date);
+});

--- a/tests/Unit/Services/Calendars/CalendarChronologyTest.php
+++ b/tests/Unit/Services/Calendars/CalendarChronologyTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Services\Calendars\CalendarChronology;
+use App\ValueObjects\Calendars\CalendarDate;
+use App\ValueObjects\Calendars\CalendarDefinition;
+
+function chronology(array $overrides = []): CalendarChronology
+{
+    return new CalendarChronology(CalendarDefinition::fromArray(array_merge([
+        'months' => [
+            ['name' => 'First', 'length' => 30],
+            ['name' => 'Second', 'length' => 30],
+        ],
+        'weekdays' => ['One', 'Two', 'Three', 'Four', 'Five'],
+    ], $overrides)));
+}
+
+it('round trips dates through a continuous ordinal timeline', function () {
+    $chronology = chronology();
+
+    foreach ([
+        new CalendarDate(-2, 2, 30),
+        new CalendarDate(-1, 1, 1),
+        new CalendarDate(0, 1, 1),
+        new CalendarDate(1, 2, 30),
+        new CalendarDate(3, 1, 1),
+    ] as $date) {
+        expect($chronology->fromOrdinal($chronology->toOrdinal($date)))->toEqual($date);
+    }
+});
+
+it('skips year zero when configured to do so', function () {
+    $chronology = chronology(['skip_year_zero' => true]);
+
+    expect($chronology->addDays(new CalendarDate(-1, 2, 30), 1))
+        ->toEqual(new CalendarDate(1, 1, 1));
+    expect($chronology->addDays(new CalendarDate(1, 1, 1), -1))
+        ->toEqual(new CalendarDate(-1, 2, 30));
+});
+
+it('applies multiple leap rules to month lengths and year lengths', function () {
+    $chronology = chronology([
+        'leap_rules' => [
+            ['amount' => 1, 'month' => 1, 'interval' => 2, 'start' => 1],
+            ['amount' => 2, 'month' => 2, 'interval' => 3, 'start' => 1],
+        ],
+    ]);
+
+    expect($chronology->isLeapYear(1))->toBeTrue()
+        ->and($chronology->daysInMonth(1, 1))->toBe(31)
+        ->and($chronology->daysInMonth(1, 2))->toBe(32)
+        ->and($chronology->daysInYear(1))->toBe(63);
+});
+
+it('moves through leap days instead of skipping them', function () {
+    $chronology = new CalendarChronology(CalendarDefinition::fromArray([
+        'months' => [
+            ['name' => 'First', 'length' => 31],
+            ['name' => 'Second', 'length' => 28],
+            ['name' => 'Third', 'length' => 31],
+        ],
+        'leap_rules' => [
+            ['amount' => 1, 'month' => 2, 'interval' => 4, 'start' => 4],
+        ],
+    ]));
+
+    expect($chronology->addDays(new CalendarDate(4, 2, 28), 1))
+        ->toEqual(new CalendarDate(4, 2, 29))
+        ->and($chronology->addDays(new CalendarDate(4, 2, 29), 1))
+        ->toEqual(new CalendarDate(4, 3, 1));
+});
+
+it('uses an explicit policy for invalid monthly dates', function () {
+    $chronology = chronology([
+        'months' => [
+            ['name' => 'Short', 'length' => 28],
+            ['name' => 'Long', 'length' => 31],
+        ],
+    ]);
+    $anchor = new CalendarDate(1, 2, 31);
+
+    expect($chronology->addMonths($anchor, 1))->toBeNull()
+        ->and($chronology->addMonths($anchor, 1, 'clamp'))->toEqual(new CalendarDate(2, 1, 28));
+});
+
+it('calculates weekdays from the same ordinal used for date arithmetic', function () {
+    $chronology = chronology(['start_offset' => 2]);
+
+    expect($chronology->weekdayIndex(new CalendarDate(0, 1, 1)))->toBe(2)
+        ->and($chronology->weekdayIndex(new CalendarDate(0, 2, 1)))->toBe(2);
+});

--- a/tests/Unit/Services/Calendars/MoonPhaseCalculatorTest.php
+++ b/tests/Unit/Services/Calendars/MoonPhaseCalculatorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Services\Calendars\CalendarChronology;
+use App\Services\Calendars\MoonPhaseCalculator;
+use App\ValueObjects\Calendars\CalendarDate;
+use App\ValueObjects\Calendars\CalendarDefinition;
+
+function moonCalculator(array $moons = []): MoonPhaseCalculator
+{
+    return new MoonPhaseCalculator(new CalendarChronology(CalendarDefinition::fromArray([
+        'months' => [
+            ['name' => 'First', 'length' => 30],
+            ['name' => 'Second', 'length' => 30],
+        ],
+        'weekdays' => ['One', 'Two', 'Three', 'Four', 'Five'],
+        'moons' => $moons ?: [
+            ['id' => 1, 'name' => 'Luna', 'fullmoon' => 16, 'offset' => 0, 'colour' => 'grey'],
+        ],
+    ])));
+}
+
+it('returns the latest phase and its age for every date', function () {
+    $calculator = moonCalculator();
+
+    $state = $calculator->statesAt(new CalendarDate(0, 1, 3))[0];
+    expect($state->phase)->toBe('full')
+        ->and($state->daysSincePhase)->toBe(2)
+        ->and($state->phaseDate)->toEqual(new CalendarDate(0, 1, 1));
+
+    $exact = $calculator->statesAt(new CalendarDate(0, 1, 5))[0];
+    expect($exact->phase)->toBe('last_quarter')
+        ->and($exact->isExact())->toBeTrue();
+});
+
+it('applies offsets to absolute phase ordinals', function () {
+    $calculator = moonCalculator([
+        ['id' => 1, 'name' => 'Luna', 'fullmoon' => 10, 'offset' => 2],
+    ]);
+
+    $phases = $calculator->phasesBetween(new CalendarDate(0, 1, 2), new CalendarDate(0, 1, 3));
+
+    expect($phases)->toHaveCount(1)
+        ->and($phases[0]->phase)->toBe('full')
+        ->and($phases[0]->date)->toEqual(new CalendarDate(0, 1, 3));
+});
+
+it('uses mathematical flooring for fractional and negative phase boundaries', function () {
+    $calculator = moonCalculator([
+        ['id' => 1, 'name' => 'Luna', 'fullmoon' => '2.5', 'offset' => 0],
+    ]);
+
+    $phases = $calculator->phasesBetween(new CalendarDate(-1, 2, 28), new CalendarDate(0, 1, 2));
+    $fullMoons = array_values(array_filter($phases, static fn ($phase): bool => $phase->phase === 'full'));
+
+    expect($fullMoons[0]->date)->toEqual(new CalendarDate(-1, 2, 28))
+        ->and($fullMoons[1]->date)->toEqual(new CalendarDate(0, 1, 1));
+});
+
+it('keeps multiple moons independent', function () {
+    $calculator = moonCalculator([
+        ['id' => 1, 'name' => 'Luna', 'fullmoon' => 16, 'offset' => 0],
+        ['id' => 2, 'name' => 'Selene', 'fullmoon' => 20, 'offset' => 4],
+    ]);
+
+    $states = $calculator->statesAt(new CalendarDate(0, 1, 1));
+
+    expect($states)->toHaveCount(2)
+        ->and($states[0]->moonId)->toBe(1)
+        ->and($states[1]->moonId)->toBe(2);
+});

--- a/tests/Unit/Services/Calendars/OccurrenceEngineTest.php
+++ b/tests/Unit/Services/Calendars/OccurrenceEngineTest.php
@@ -65,12 +65,48 @@ it('honours an inclusive recurring end year', function () {
         ->toBe([0, 1]);
 });
 
+it('classifies an active multi-day reminder as upcoming', function () {
+    $engine = occurrenceEngine();
+    $anchor = new CalendarDate(0, 1, 1);
+    $pivot = new CalendarDate(0, 1, 2);
+
+    $active = $engine->nextOrActiveOccurrence($anchor, 3, null, $pivot);
+    $past = $engine->previousOccurrence($anchor, 3, null, $pivot);
+
+    expect($active?->start)->toEqual($anchor)
+        ->and($past)->toBeNull();
+});
+
+it('finds the previous and next monthly occurrences without expanding the full history', function () {
+    $engine = occurrenceEngine();
+    $rule = new RecurrenceRule(RecurrenceRule::MONTHLY);
+    $anchor = new CalendarDate(0, 1, 30);
+    $pivot = new CalendarDate(1, 1, 3);
+
+    expect($engine->previousOccurrence($anchor, 3, $rule, $pivot)?->start)
+        ->toEqual(new CalendarDate(0, 2, 30))
+        ->and($engine->nextOrActiveOccurrence($anchor, 3, $rule, $pivot)?->start)
+        ->toEqual(new CalendarDate(1, 1, 30));
+});
+
+it('uses the shared moon calculator for moon recurrence', function () {
+    $engine = occurrenceEngine();
+    $rule = new RecurrenceRule(RecurrenceRule::MOON_PHASE, moonId: 1, phase: 'full');
+
+    expect($engine->nextOrActiveOccurrence(
+        new CalendarDate(0, 1, 1),
+        1,
+        $rule,
+        new CalendarDate(0, 1, 2),
+    )?->start)->toEqual(new CalendarDate(0, 1, 11));
+});
+
 it('adapts legacy monthly, yearly, and moon recurrence values', function () {
     $adapter = new LegacyRecurrenceAdapter;
 
-    $monthly = new Reminder(['recurring_periodicity' => 'month', 'recurring_until' => '4']);
-    $yearly = new Reminder(['recurring_periodicity' => 'year']);
-    $moon = new Reminder(['recurring_periodicity' => '2_f']);
+    $monthly = new Reminder(['is_recurring' => true, 'recurring_periodicity' => 'month', 'recurring_until' => '4']);
+    $yearly = new Reminder(['is_recurring' => true, 'recurring_periodicity' => 'year']);
+    $moon = new Reminder(['is_recurring' => true, 'recurring_periodicity' => '2_f']);
 
     expect($adapter->fromReminder($monthly)->frequency)->toBe(RecurrenceRule::MONTHLY)
         ->and($adapter->fromReminder($monthly)->untilYear)->toBe(4)
@@ -81,7 +117,7 @@ it('adapts legacy monthly, yearly, and moon recurrence values', function () {
 
 it('rejects unsupported legacy recurrence values', function () {
     $adapter = new LegacyRecurrenceAdapter;
-    $reminder = new Reminder(['recurring_periodicity' => 'fortnight']);
+    $reminder = new Reminder(['is_recurring' => true, 'recurring_periodicity' => 'fortnight']);
 
     expect(fn () => $adapter->fromReminder($reminder))
         ->toThrow(InvalidArgumentException::class);
@@ -90,6 +126,7 @@ it('rejects unsupported legacy recurrence values', function () {
 it('rejects malformed legacy recurrence end years', function () {
     $adapter = new LegacyRecurrenceAdapter;
     $reminder = new Reminder([
+        'is_recurring' => true,
         'recurring_periodicity' => 'year',
         'recurring_until' => 'later',
     ]);

--- a/tests/Unit/Services/Calendars/OccurrenceEngineTest.php
+++ b/tests/Unit/Services/Calendars/OccurrenceEngineTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Models\Reminder;
+use App\Services\Calendars\CalendarChronology;
+use App\Services\Calendars\LegacyRecurrenceAdapter;
+use App\Services\Calendars\OccurrenceEngine;
+use App\ValueObjects\Calendars\CalendarDate;
+use App\ValueObjects\Calendars\CalendarDefinition;
+use App\ValueObjects\Calendars\RecurrenceRule;
+
+function occurrenceEngine(): OccurrenceEngine
+{
+    return new OccurrenceEngine(new CalendarChronology(CalendarDefinition::fromArray([
+        'months' => [
+            ['name' => 'First', 'length' => 30],
+            ['name' => 'Second', 'length' => 30],
+        ],
+        'weekdays' => ['One', 'Two', 'Three', 'Four', 'Five'],
+        'moons' => [
+            ['id' => 1, 'name' => 'Moon', 'fullmoon' => 10, 'offset' => 0],
+        ],
+    ])));
+}
+
+it('expands fortnightly recurrence using the calendar week length', function () {
+    $engine = occurrenceEngine();
+    $occurrences = $engine->occurrences(
+        new CalendarDate(0, 1, 1),
+        1,
+        new RecurrenceRule(RecurrenceRule::WEEKLY, interval: 2),
+        new CalendarDate(0, 1, 1),
+        new CalendarDate(0, 2, 10),
+    );
+
+    expect(array_map(fn ($occurrence) => $occurrence->start->key(), $occurrences))
+        ->toBe(['0-1-1', '0-1-11', '0-1-21', '0-2-1']);
+});
+
+it('expands monthly recurrence and includes an event ending in the window', function () {
+    $engine = occurrenceEngine();
+    $occurrences = $engine->occurrences(
+        new CalendarDate(0, 1, 30),
+        3,
+        new RecurrenceRule(RecurrenceRule::MONTHLY),
+        new CalendarDate(0, 2, 1),
+        new CalendarDate(0, 2, 2),
+    );
+
+    expect($occurrences)->toHaveCount(1)
+        ->and($occurrences[0]->start)->toEqual(new CalendarDate(0, 1, 30))
+        ->and($occurrences[0]->end)->toEqual(new CalendarDate(0, 2, 2));
+});
+
+it('honours an inclusive recurring end year', function () {
+    $engine = occurrenceEngine();
+    $occurrences = $engine->occurrences(
+        new CalendarDate(0, 1, 1),
+        1,
+        new RecurrenceRule(RecurrenceRule::YEARLY, untilYear: 1),
+        new CalendarDate(0, 1, 1),
+        new CalendarDate(2, 2, 1),
+    );
+
+    expect(array_map(fn ($occurrence) => $occurrence->start->year, $occurrences))
+        ->toBe([0, 1]);
+});
+
+it('adapts legacy monthly, yearly, and moon recurrence values', function () {
+    $adapter = new LegacyRecurrenceAdapter;
+
+    $monthly = new Reminder(['recurring_periodicity' => 'month', 'recurring_until' => '4']);
+    $yearly = new Reminder(['recurring_periodicity' => 'year']);
+    $moon = new Reminder(['recurring_periodicity' => '2_f']);
+
+    expect($adapter->fromReminder($monthly)->frequency)->toBe(RecurrenceRule::MONTHLY)
+        ->and($adapter->fromReminder($monthly)->untilYear)->toBe(4)
+        ->and($adapter->fromReminder($yearly)->frequency)->toBe(RecurrenceRule::YEARLY)
+        ->and($adapter->fromReminder($moon)->moonId)->toBe(2)
+        ->and($adapter->fromReminder($moon)->phase)->toBe('full');
+});
+
+it('rejects unsupported legacy recurrence values', function () {
+    $adapter = new LegacyRecurrenceAdapter;
+    $reminder = new Reminder(['recurring_periodicity' => 'fortnight']);
+
+    expect(fn () => $adapter->fromReminder($reminder))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects malformed legacy recurrence end years', function () {
+    $adapter = new LegacyRecurrenceAdapter;
+    $reminder = new Reminder([
+        'recurring_periodicity' => 'year',
+        'recurring_until' => 'later',
+    ]);
+
+    expect(fn () => $adapter->fromReminder($reminder))
+        ->toThrow(InvalidArgumentException::class);
+});


### PR DESCRIPTION
Modernise the calendar engine
- Fix multiple leap year bugs
- Move the recurrence code into it's own ValueObject concepts
- Remove all the rendering logic out of models/services
- Remove all the calculations from blade
- Prepare foundation for more moon phases
- Prepare foundation for multiple leap years